### PR TITLE
Minor fixes

### DIFF
--- a/TestProjects/SampleProject1/Packages/manifest.json
+++ b/TestProjects/SampleProject1/Packages/manifest.json
@@ -3,11 +3,10 @@
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.ext.nunit": "1.0.0",
-    "com.unity.ide.rider": "1.0.4",
-    "com.unity.ide.visualstudio": "1.0.5",
-    "com.unity.ide.vscode": "1.0.4",
+    "com.unity.ide.rider": "1.1.4",
+    "com.unity.ide.vscode": "1.1.4",
     "com.unity.mobile.android-logcat": "file:../../../com.unity.mobile.android-logcat",
-    "com.unity.test-framework": "1.0.13",
+    "com.unity.test-framework": "1.1.11",
     "com.unity.test-framework.performance": "1.2.5-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
@@ -42,7 +41,6 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
-  "registry": "https://staging-packages.unity.com",
   "testables": [
     "com.unity.mobile.android-logcat",
     "com.unity.test-framework.performance"

--- a/TestProjects/SampleProject1/Packages/manifest.json
+++ b/TestProjects/SampleProject1/Packages/manifest.json
@@ -41,6 +41,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "registry": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates",
   "testables": [
     "com.unity.mobile.android-logcat",
     "com.unity.test-framework.performance"

--- a/TestProjects/SampleProject1/ProjectSettings/ProjectVersion.txt
+++ b/TestProjects/SampleProject1/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.2.0b7
-m_EditorVersionWithRevision: 2019.2.0b7 (87c9ecb96495)
+m_EditorVersion: 2019.3.7f1
+m_EditorVersionWithRevision: 2019.3.7f1 (6437fd74d35d)

--- a/TestProjects/SampleProject1/ProjectSettings/XRSettings.asset
+++ b/TestProjects/SampleProject1/ProjectSettings/XRSettings.asset
@@ -1,0 +1,10 @@
+{
+    "m_SettingKeys": [
+        "VR Device Disabled",
+        "VR Device User Alert"
+    ],
+    "m_SettingValues": [
+        "False",
+        "False"
+    ]
+}

--- a/TestProjects/SampleProject2019.1Net35/Packages/manifest.json
+++ b/TestProjects/SampleProject2019.1Net35/Packages/manifest.json
@@ -8,7 +8,6 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
-  "registry": "https://staging-packages.unity.com",
   "testables": [
     "com.unity.mobile.android-logcat"
   ]

--- a/TestProjects/SampleProject2019.1Net35/Packages/manifest.json
+++ b/TestProjects/SampleProject2019.1Net35/Packages/manifest.json
@@ -8,6 +8,7 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
+  "registry": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates",
   "testables": [
     "com.unity.mobile.android-logcat"
   ]

--- a/com.unity.mobile.android-logcat/ValidationConfig.json.meta
+++ b/com.unity.mobile.android-logcat/ValidationConfig.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c828def85813c95488cfcbbf0551c1a3
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Update  TestProjects/SampleProject1 to 2019.3, since we don't even test for 2019.2 anymore
* Remove "registry": "https://staging-packages.unity.com", since it was deprecated and switch to "registry": "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates". As we might still want to access internal packages
* Add missing meta file