### PR TITLE
Disable memory window by default

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix Memory Window on Android 11. Android 11 started dumping RSS memory, which was previously unexpected by Memory Window.
  - Include RSS memory in Memory window. 
 
+### Changes
+ - Memory window will be disabled by default, since it causes **Explicit concurrent copying GC freed** messages to be printed in the logcat which might unwanted behavior.
+
 ## [1.2.0] - 2020-08-18
 
 ### Fix & Improvements.

--- a/com.unity.mobile.android-logcat/Documentation~/MemoryWindow.md
+++ b/com.unity.mobile.android-logcat/Documentation~/MemoryWindow.md
@@ -79,3 +79,12 @@ Here are few examples which memory goes where:
 * You can disable/enable memory types by toggling in the left pane.
 
 * You can select a memory request result by clicking in the right pane.
+
+
+#### Note
+
+When memory window is enabled and requesting captures, you might see the following messages on logcat being constantly printed, this is normal:
+
+    Explicit concurrent copying GC freed 5515(208KB) AllocSpace objects, 1(20KB) LOS objects, 49% free, 1926KB/3852KB, paused 46us total 11.791ms
+
+Disabling the memory window will stop printing these messages.

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatMemoryViewer.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatMemoryViewer.cs
@@ -20,7 +20,7 @@ namespace Unity.Android.Logcat
         public float MemoryWindowWidth;
         public bool[] MemoryTypeEnabled;
         public MemoryGroup MemoryGroup = MemoryGroup.HeapAlloc;
-        public MemoryViewerBehavior Behavior = MemoryViewerBehavior.Auto;
+        public MemoryViewerBehavior Behavior = MemoryViewerBehavior.Hidden;
     }
 
     internal class AndroidLogcatMemoryViewer


### PR DESCRIPTION
## **Please read and consider what information you want to pass on to people reviewing this PR**

### Purpose of PR
**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [X] Behavior change

Memory window will be disabled by default, I already noticed this earlier, but now it's being reported in forums too:
https://forum.unity.com/threads/explicit-concurrent-copying-gc-freed-allocspace-objects.1012450/#post-6563137

This message is constantly being printed to logcat:
Explicit concurrent copying GC freed 5515(208KB) AllocSpace objects, 1(20KB) LOS objects, 49% free, 1926KB/3852KB, paused 46us total 11.791ms

It seems to be caused by memory dump, and can be really spammy. And since most users probably don't want to look at the memory by default, I think it makes sense to disable it by default.

* **Links to screenshots, design docs, user docs, etc.**
* **Links to Jira/Fogbugz cases**
* **Halo effect**
None
* **Performance Impact**
_Could this PR affect performance? If so, what has been done to measure time taken per frame, memory used, etc.?_
* **Package requirements**
_What Unity Editor version is required/supported? Any other dependancy packages needed?_

### Checklist for PR maker
- [ ] Have you added a backport label? (if needed)
- [ ] Have you updated the Changelog? _Each package has a `CHANGELOG.md` file_
- [X] **Have you added or updated the Documentation to your PR?** 
Added a note in docs.
---
### Testing status
* **Existing or new automation tests - what automation was added, changed**
None
* **Detailed description of what testing was done, what projects were run**
Deleted android settings, and checked that opening logcat doesn't display memory window by default
* **What environment did you test on?**
Windows
* **Projects**
Tested with project from repo
* **Testing checklist**
- [ ] Built and run editor Locally or Katana
- [ ] Built a player Android/iOS (if applicable)
- [ ] Run on device Android/iOS (if applicable)
- [ ] If new feature has UI, does it match Unity style? (Unity [HIG](https://unitytech.github.io/unityeditor-hig/)?)
- [ ] Tested Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] All items have tooltips?
---
### Note to guardian
_Changeset to use, if extra changesets on top. Any other notes to pass along_

### Comments to reviewers
_Notes for the reviewers you have assigned_
