### PR TITLE
Remove automatic stacktrace resolving in logcat messages 

### DIFF
--- a/TestProjects/ForceCrash/ProjectSettings/EditorBuildSettings.asset
+++ b/TestProjects/ForceCrash/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/SampleScene.unity
+    guid: 9fc0d4010bbf28b4594072e72b8655ab
   m_configObjects: {}

--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changes
  - Memory window will be disabled by default, since it causes **Explicit concurrent copying GC freed** messages to be printed in the logcat which might unwanted behavior.
+ - Remove automatic stacktrace resolving when receiving logcat messages, since in some cases it's impossible to automatically determine the correct symbol path, this creates a misleading behavior, where displayed stacktraces are incorrect. Please use Stacktrace Utility instead.
 
 ## [1.2.0] - 2020-08-18
 

--- a/com.unity.mobile.android-logcat/Documentation~/index.md
+++ b/com.unity.mobile.android-logcat/Documentation~/index.md
@@ -34,18 +34,3 @@ The toolbar is on the top of the window. Most Android Logcat controls can be fou
 
 ### Auto Run
 When **Auto Run** is toggled, Android Logcat window will be launched automatically if you do **Build And Run** in **Build Settings** window.
-
-### Stacktrace Resolving
-One benefit of using Android Logcat package is automatic stacktrace resolving. The **addr2line** tool in Android NDK is used to convert the addresses in the crash logs to the file names and line numbers. Below is an example of what's added to the log.
-
-**_The original log from Android logcat_**
-
-	E CRASH   :      #01  pc 01c65330  /data/app/com.CrashComp.Crash-J2Z_L0XSsSAZPkt9lab2rQ==/lib/arm/libunity.so(DiagnosticsUtils_Bindings::ForceCrash(DiagnosticsUtils_Bindings::ForcedCrashCategory, ScriptingExceptionPtr*)+48)
-
-**_The log shown in Android Logcat window in the Unity Editor_**
-
-	Error CRASH: 	#01  pc 01c65330  /data/app/com.CrashComp.Crash-J2Z_L0XSsSAZPkt9lab2rQ==/lib/arm/libunity.so DiagnosticsUtils_Bindings::ForceCrash(DiagnosticsUtils_Bindings::ForcedCrashCategory, ScriptingExceptionPtr*) at ../Runtime/Export/Diagnostics/DiagnosticsUtils.bindings.cpp:25
-
-To use this feature, you need to 
-- Have Android NDK installed and set the NDK path in Unity (Menu: **Editor** \> **Preferences...** \> **External Tools**).
-- Have the corresponding symbol files installed with Unity.

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
@@ -312,7 +312,7 @@ namespace Unity.Android.Logcat
                 PriorityStringToEnum(m.Groups["priority"].Value),
                 m.Groups["tag"].Value,
                 m.Groups["msg"].Value);
-            
+
             return entry;
         }
 
@@ -331,7 +331,7 @@ namespace Unity.Android.Logcat
                     throw new InvalidOperationException(string.Format("Invalid `priority` ({0}) in log entry.", priority));
             }
         }
-        
+
         private void OnDataReceived(string message)
         {
             // You can receive null string, when you put out USB cable out of PC and logcat connection is lost

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
@@ -190,7 +190,6 @@ namespace Unity.Android.Logcat
         internal void Stop()
         {
             m_CachedLogLines.Clear();
-            m_BuildInfos.Clear();
             m_Runtime.Update -= OnUpdate;
             if (m_MessageProvider != null && !m_MessageProvider.HasExited)
             {
@@ -265,7 +264,6 @@ namespace Unity.Android.Logcat
             if (entries.Count == 0)
                 return;
 
-            ResolveStackTrace(entries);
             LogEntriesAdded(entries);
         }
 
@@ -314,19 +312,7 @@ namespace Unity.Android.Logcat
                 PriorityStringToEnum(m.Groups["priority"].Value),
                 m.Groups["tag"].Value,
                 m.Groups["msg"].Value);
-
-            if ((entry.priority == Priority.Info && entry.tag.GetHashCode() == kUnityHashCode && entry.message.StartsWith("Built from")) ||
-                (entry.priority == Priority.Error && entry.tag.GetHashCode() == kCrashHashCode && entry.message.StartsWith("Build type")))
-            {
-                m_BuildInfos[entry.processId] = AndroidLogcatUtilities.ParseBuildInfo(entry.message);
-            }
-
-            if (entry.priority == Priority.Fatal && entry.tag.GetHashCode() == kDebugHashCode && entry.message.StartsWith("pid:"))
-            {
-                // Crash reported by Android for some pid, need to update buildInfo information for this new pid as well
-                ParseCrashBuildInfo(entry.processId, entry.message);
-            }
-
+            
             return entry;
         }
 
@@ -345,157 +331,7 @@ namespace Unity.Android.Logcat
                     throw new InvalidOperationException(string.Format("Invalid `priority` ({0}) in log entry.", priority));
             }
         }
-
-        private void ParseCrashBuildInfo(int processId, string msg)
-        {
-            var reg = new Regex(@"pid: '(.+)'");
-            Match match = reg.Match(msg);
-
-            if (match.Success)
-            {
-                int pid = Int32.Parse(match.Groups[1].Value);
-                if (pid != processId && m_BuildInfos.ContainsKey(pid))
-                    m_BuildInfos[processId] = m_BuildInfos[pid];
-            }
-        }
-
-        public struct UnresolvedAddress
-        {
-            public int logEntryIndex;
-            public string unresolvedAddress;
-        };
-
-        private void ResolveStackTrace(List<LogEntry> entries)
-        {
-            var unresolvedAddresses = new Dictionary<KeyValuePair<BuildInfo, string>, List<UnresolvedAddress>>();
-
-            // Gather unresolved address if there are any
-            for (int i = 0; i < entries.Count; i++)
-            {
-                var entry = entries[i];
-                // Only process stacktraces from Error/Fatal priorities
-                if (entry.priority != Priority.Error && entry.priority != Priority.Fatal)
-                    continue;
-
-                // Only process stacktraces if tag is "CRASH" or "DEBUG"
-                if (entry.tag.GetHashCode() != kCrashHashCode && entry.tag.GetHashCode() != kDebugHashCode)
-                    continue;
-
-                BuildInfo buildInfo;
-                // Unknown build info, that means we don't know where the symbols are located
-                if (!m_BuildInfos.TryGetValue(entry.processId, out buildInfo))
-                    continue;
-
-                string address, libName;
-                if (!AndroidLogcatUtilities.ParseCrashLine(m_Runtime.Settings.StacktraceResolveRegex, entry.message, out address, out libName))
-                    continue;
-
-                List<UnresolvedAddress> addresses;
-                var key = new KeyValuePair<BuildInfo, string>(buildInfo, libName);
-                if (!unresolvedAddresses.TryGetValue(key, out addresses))
-                    unresolvedAddresses[key] = new List<UnresolvedAddress>();
-
-                unresolvedAddresses[key].Add(new UnresolvedAddress() { logEntryIndex = i, unresolvedAddress = address });
-            }
-
-            if (!BuildPipeline.IsBuildTargetSupported(BuildTargetGroup.Android, BuildTarget.Android))
-                return;
-
-            var engineDirectory = BuildPipeline.GetPlaybackEngineDirectory(BuildTarget.Android, BuildOptions.None);
-
-            // Resolve addresses
-            foreach (var u in unresolvedAddresses)
-            {
-                var buildInfo = u.Key.Key;
-                var libName = u.Key.Value;
-
-                var addresses = u.Value;
-                var symbolPath = CombinePaths(engineDirectory, "Variations", buildInfo.scriptingImplementation, buildInfo.buildType, "Symbols", buildInfo.cpu);
-                var libpath = AndroidLogcatUtilities.GetSymbolFile(symbolPath, libName);
-
-                // For optimizations purposes, we batch addresses which belong to same library, so addr2line can be ran less
-                try
-                {
-                    string[] result;
-                    if (!string.IsNullOrEmpty(libpath))
-                        result = m_Runtime.Tools.RunAddr2Line(libpath, addresses.Select(m => m.unresolvedAddress).ToArray());
-                    else
-                    {
-                        result = new string[addresses.Count];
-                        for (int i = 0; i < addresses.Count; i++)
-                            result[i] = string.Empty;
-                    }
-
-                    for (int i = 0; i < addresses.Count; i++)
-                    {
-                        var idx = addresses[i].logEntryIndex;
-                        var append = string.IsNullOrEmpty(result[i]) ? "(Not Resolved)" : result[i];
-                        entries[idx] = new LogEntry(entries[idx]) { message = ModifyLogEntry(entries[idx].message, append, false)};
-                    }
-                }
-                catch (Exception ex)
-                {
-                    for (int i = 0; i < addresses.Count; i++)
-                    {
-                        var idx = addresses[i].logEntryIndex;
-                        entries[idx] = new LogEntry(entries[idx]) { message = ModifyLogEntry(entries[idx].message, "(Addr2Line failure)", true) };
-                        var errorMessage = new StringBuilder();
-                        errorMessage.AppendLine("Addr2Line failure");
-                        errorMessage.AppendLine("Full Entry Message: " + entries[idx].message);
-                        errorMessage.AppendLine("Scripting Backend: " + buildInfo.scriptingImplementation);
-                        errorMessage.AppendLine("Build Type: " + buildInfo.buildType);
-                        errorMessage.AppendLine("CPU: " + buildInfo.cpu);
-                        errorMessage.AppendLine(ex.Message);
-                        UnityEngine.Debug.LogError(errorMessage.ToString());
-                    }
-                }
-            }
-        }
-
-        private string CombinePaths(params string[] paths)
-        {
-            // Unity hasn't implemented System.IO.Path(string[]), we have to do it on our own.
-            if (paths.Length == 0)
-                return "";
-
-            string path = paths[0];
-            for (int i = 1; i < paths.Length; ++i)
-                path = System.IO.Path.Combine(path, paths[i]);
-            return path;
-        }
-
-        private bool ParseCrashMessage(string msg, out string address, out string libName)
-        {
-            var match = m_CrashMessageRegex.Match(msg);
-            if (match.Success)
-            {
-                address = match.Groups[1].Value;
-                libName = match.Groups[2].Value;
-                return true;
-            }
-            address = null;
-            libName = null;
-            return false;
-        }
-
-        private string ModifyLogEntry(string msg, string appendText, bool keeplOriginalMessage)
-        {
-            if (keeplOriginalMessage)
-            {
-                return msg + " " + appendText;
-            }
-            else
-            {
-                var match = m_CrashMessageRegex.Match(msg);
-                return match.Success ? match.Groups[0].Value + " " + appendText : msg + " " + appendText;
-            }
-        }
-
-        private string PriorityEnumToString(Priority priority)
-        {
-            return priority.ToString().Substring(0, 1);
-        }
-
+        
         private void OnDataReceived(string message)
         {
             // You can receive null string, when you put out USB cable out of PC and logcat connection is lost
@@ -523,8 +359,6 @@ namespace Unity.Android.Logcat
         {
             get { return m_Device.SupportYearFormat ? kYearTime : kThreadTime; }
         }
-
-        private Dictionary<int, BuildInfo> m_BuildInfos = new Dictionary<int, BuildInfo>();
 
         internal static Regex m_CrashMessageRegex = new Regex(@"^\s*#\d{2}\s*pc\s([a-fA-F0-9]{8}).*(libunity\.so|libmain\.so)", RegexOptions.Compiled);
         // Regex for messages produced via 'adb logcat -s -v year *:V'


### PR DESCRIPTION
## **Please read and consider what information you want to pass on to people reviewing this PR**

### Purpose of PR
**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [X] Remove faulty optional feature

* **Description of the feature**
This PR remove automatic stacktrace resolving as per https://github.com/Unity-Technologies/com.unity.mobile.logcat/issues/118 . Since in some cases it's impossible to correctly determine symbol path, it's better for this feature not to exist, since it shows incorrect stacktraces. It's better to use stacktrace utility, where you have more control over where to look for symbols.
* **Links to screenshots, design docs, user docs, etc.**
* **Links to Jira/Fogbugz cases**
* **Halo effect**
none
* **Performance Impact**
none
* **Package requirements**
2019.1 and up

### Checklist for PR maker
- [ ] Have you added a backport label? (if needed)
- [X] Have you updated the Changelog? _Each package has a `CHANGELOG.md` file_
- [X] **Have you added or updated the Documentation to your PR?** 
Remove relevant entries from documentation

---
### Testing status
* **Existing or new automation tests - what automation was added, changed**
Used existing automated test
* **Detailed description of what testing was done, what projects were run**
Checked that when android app crashes, we don't automatically resolve stacktraces
* **What environment did you test on?**
Windows
* **Projects**
Used ForceCrash project from repo
* **Testing checklist**
- [ ] Built and run editor Locally or Katana
- [ ] Built a player Android/iOS (if applicable)
- [ ] Run on device Android/iOS (if applicable)
- [ ] If new feature has UI, does it match Unity style? (Unity [HIG](https://unitytech.github.io/unityeditor-hig/)?)
- [ ] Tested Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] All items have tooltips?
---
### Note to guardian

### Comments to reviewers

