### PR TITLE
Add Linux Editor CI support

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -41,6 +41,10 @@ pack:
 {% for editor in test_editors %}
 {% for platform in test_platforms %}
 {% for module_support in test_module_support %}
+{% if platform.name == "linux" and module_support.name == "android" and editor.version == "2019.2" or editor.version == "2019.4" %}
+   {% continue %}
+{% endif %}
+
 test_{{ platform.name }}_{{ editor.version }}_{{ module_support.name }}:
   name : Test {{ editor.version }} on {{ platform.name }} with install '{{ module_support.name }}'
   agent:
@@ -88,6 +92,9 @@ test_all_trigger:
     {% for editor in test_editors %}
     {% for platform in test_platforms %}
     {% for module_support in test_module_support %}
+    {% if platform.name == "linux" and module_support.name == "android" and editor.version == "2019.2" or editor.version == "2019.4" %}
+        {% continue %}
+    {% endif %}
     - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}_{{ module_support.name }}
     {% endfor %}
     {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -13,6 +13,10 @@ test_platforms:
     type: Unity::VM::osx
     image: package-ci/mac:stable
     flavor: m1.mac
+  - name: linux
+    type: Unity::VM
+    image: desktop/ubuntu-18.04-desktop-katana
+    flavor: b1.large
 test_module_support:
   - name: no_support
     install_command:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -15,7 +15,7 @@ test_platforms:
     flavor: m1.mac
   - name: linux
     type: Unity::VM
-    image: desktop/ubuntu-18.04-desktop-katana
+    image: package-ci/ubuntu:stable
     flavor: b1.large
 test_module_support:
   - name: no_support


### PR DESCRIPTION
Added Linux editor CI + with and without android module installed.

It seems it's impossible to get Android module for Linux on versions 2019.2/2019.4 so skip those