### PR TITLE
Added Max exited packages option

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fixed tiny issue, when right clicking on the log message, the tag and process id for context menu was being taken from the first selected item, now it will be taken from item which you're hovering on
  - Fixed issue, when right clicking on the log message with tag containing forward slash, the menu would be incorrectly displayed.
  - Fixed issue, where logcat package would freeze, if you would click Clear after disconnecting the device.
+ - Add setting for controlling how many exited packages to show in package selection.
 
 ### Fixes & Improvements.
  - Bump minimum Unity version support from 2019.2 to 2019.4

--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fixed issue, when right clicking on the log message with tag containing forward slash, the menu would be incorrectly displayed.
  - Fixed issue, where logcat package would freeze, if you would click Clear after disconnecting the device.
  - Add setting for controlling how many exited packages to show in package selection.
+ - Add doc about known issue where logcat might work incorrectly if there more than one Editor instance running.
 
 ### Fixes & Improvements.
  - Bump minimum Unity version support from 2019.2 to 2019.4

--- a/com.unity.mobile.android-logcat/Documentation~/index.md
+++ b/com.unity.mobile.android-logcat/Documentation~/index.md
@@ -2,11 +2,11 @@
 
 Android Logcat Package is a utility for displaying log messages coming from an Android device in the Unity Editor. Read more about [Android Logcat Document](https://developer.android.com/studio/command-line/logcat).
 
-**Requirements**
+#### Requirements
 - Compatible with Unity 2019.2 or above.
 - Requires Unity's Android support module.
 
-**Supported features**
+####  Supported features
 - Device connnection
 	- Via USB
 	- Via Wifi
@@ -31,5 +31,9 @@ Android Logcat Package is a utility for displaying log messages coming from an A
 The toolbar is on the top of the window. Most Android Logcat controls can be found here.  
 ![Toolbar](images/android_logcat_toolbar.png)
 
-### Auto Run
+#### Auto Run
 When **Auto Run** is toggled, Android Logcat window will be launched automatically if you do **Build And Run** in **Build Settings** window.
+
+#### Known Issues
+##### **Don't run more than one instance of Editor from different locations**
+  Android Logcat package uses adb process from Android SDK which is installed together with Unity. Unity periodically kills adb instances if they are from different Android SDK location than the one set in Preferences->External Tools->Android SDK Tools. This may interfere with Android Logcat package work.

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatConsoleWindow.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatConsoleWindow.cs
@@ -147,12 +147,6 @@ namespace Unity.Android.Logcat
             m_ApplySettings = true;
         }
 
-        private void ApplySettings(AndroidLogcatSettings settings)
-        {
-            AndroidLogcatUtilities.ApplySettings(settings, m_Logcat);
-            Repaint();
-        }
-
         private void RemoveTag(string tag)
         {
             if (!m_Runtime.UserSettings.Tags.Remove(tag))
@@ -383,7 +377,8 @@ namespace Unity.Android.Logcat
 
             if (m_ApplySettings)
             {
-                ApplySettings(m_Runtime.Settings);
+                AndroidLogcatUtilities.ApplySettings(m_Runtime, m_Logcat);
+                Repaint();
                 m_ApplySettings = false;
             }
 
@@ -741,7 +736,7 @@ namespace Unity.Android.Logcat
                 m_Runtime.UserSettings.CreatePackageInformation(PlayerSettings.applicationIdentifier, projectApplicationPid, selectedDevice);
             }
 
-            m_Runtime.UserSettings.CleanupDeadPackagesForDevice(m_Runtime.DeviceQuery.SelectedDevice);
+            m_Runtime.UserSettings.CleanupDeadPackagesForDevice(m_Runtime.DeviceQuery.SelectedDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
             AndroidLogcatInternalLog.Log("UpdateDebuggablePackages finished in " + (DateTime.Now - startTime).Milliseconds + " ms");
         }
 

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatSettings.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatSettings.cs
@@ -49,6 +49,9 @@ namespace Unity.Android.Logcat
         [SerializeField]
         private List<ReordableListItem> m_StacktraceResolveRegex;
 
+        [SerializeField]
+        private int m_MaxExitedPackagesToShow;
+
         internal int MemoryRequestIntervalMS
         {
             set
@@ -106,6 +109,20 @@ namespace Unity.Android.Logcat
             return newFilteredMessageCount;
         }
 
+        internal int MaxExitedPackagesToShow
+        {
+            set
+            {
+                if (m_MaxExitedPackagesToShow == value)
+                    return;
+                m_MaxExitedPackagesToShow = value;
+                InvokeOnSettingsChanged();
+            }
+            get
+            {
+                return m_MaxExitedPackagesToShow;
+            }
+        }
         internal Font MessageFont
         {
             set
@@ -183,6 +200,7 @@ namespace Unity.Android.Logcat
             m_MaxFilteredMessageCount = 60000;
             m_MessageFont = AssetDatabase.LoadAssetAtPath<Font>("Packages/com.unity.mobile.android-logcat/Editor/Fonts/consola.ttf");
             m_MessageFontSize = 11;
+            m_MaxExitedPackagesToShow = 4;
             if (Enum.GetValues(typeof(Priority)).Length != 6)
                 throw new Exception("Unexpected length of Priority enum.");
 

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatSettingsProvider.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatSettingsProvider.cs
@@ -17,6 +17,7 @@ namespace Unity.Android.Logcat
             public static GUIContent stactraceRegex = new GUIContent("Stacktrace Regex", "Configure regex used for resolving function address and library name");
             public static GUIContent requestIntervalMS = new GUIContent("Request Interval ms",
                 $"How often to request memory dump from the device? The minimum value is {AndroidLogcatSettings.kMinMemoryRequestIntervalMS} ms");
+            public static GUIContent maxExitedPackageToShow = new GUIContent("Max Exited Packages", "The maximum number of pacakges in pacakge selection which have exited.");
         }
 
         private AndroidLogcatRuntimeBase m_Runtime;
@@ -55,6 +56,12 @@ namespace Unity.Android.Logcat
                 EditorGUILayout.IntField(Styles.requestIntervalMS, settings.MemoryRequestIntervalMS);
             GUILayout.Space(20);
 
+            GUILayout.Space(20);
+            EditorGUILayout.LabelField("Packages", EditorStyles.boldLabel);
+
+            settings.MaxExitedPackagesToShow = EditorGUILayout.IntSlider(Styles.maxExitedPackageToShow, settings.MaxExitedPackagesToShow, 1, 100);
+
+            GUILayout.Space(20);
             EditorGUILayout.LabelField(Styles.stactraceRegex, EditorStyles.boldLabel);
             m_RegexList.OnGUI(150.0f);
 

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatUserSettings.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatUserSettings.cs
@@ -10,8 +10,6 @@ namespace Unity.Android.Logcat
     [Serializable]
     internal class AndroidLogcatUserSettings
     {
-        internal const int kMaxExitedPackages = 5;
-
         [SerializeField]
         private string m_SelectedDeviceId;
         [SerializeField]
@@ -112,7 +110,7 @@ namespace Unity.Android.Logcat
             return packages;
         }
 
-        public void CleanupDeadPackagesForDevice(IAndroidLogcatDevice device)
+        public void CleanupDeadPackagesForDevice(IAndroidLogcatDevice device, int maxExitedPackagesToShow)
         {
             if (device == null)
                 return;
@@ -130,7 +128,7 @@ namespace Unity.Android.Logcat
             }
 
             // Need to remove the package which were added first, since they are the oldest packages
-            int deadPackagesToRemove = deadPackageCount - kMaxExitedPackages;
+            int deadPackagesToRemove = deadPackageCount - maxExitedPackagesToShow;
             if (deadPackagesToRemove <= 0)
                 return;
 

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatUtilities.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatUtilities.cs
@@ -452,8 +452,14 @@ namespace Unity.Android.Logcat
             UnityEditor.EditorGUILayout.HelpBox("Android Logcat requires Android support to be installed.", UnityEditor.MessageType.Info);
         }
 
-        internal static void ApplySettings(AndroidLogcatSettings settings, AndroidLogcat logcat)
+        internal static void ApplySettings(AndroidLogcatRuntimeBase runtime, AndroidLogcat logcat)
         {
+            if (runtime == null)
+                throw new NullReferenceException("AndroidLogcatRuntimeBase is null");
+            var settings = runtime.Settings;
+            var userSettings = runtime.UserSettings;
+            var selectedDevice = runtime.DeviceQuery.SelectedDevice;
+
             int fixedHeight = settings.MessageFontSize + 5;
             AndroidLogcatStyles.kLogEntryFontSize = settings.MessageFontSize;
             AndroidLogcatStyles.kLogEntryFixedHeight = fixedHeight;
@@ -473,6 +479,7 @@ namespace Unity.Android.Logcat
 
             logcat?.StripFilteredEntriesIfNeeded();
             logcat?.StripRawEntriesIfNeeded();
+            userSettings.CleanupDeadPackagesForDevice(selectedDevice, settings.MaxExitedPackagesToShow);
         }
 
         // When we use / in context menu, this creates submenu, which is no good

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatUtilities.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatUtilities.cs
@@ -455,7 +455,7 @@ namespace Unity.Android.Logcat
         internal static void ApplySettings(AndroidLogcatRuntimeBase runtime, AndroidLogcat logcat)
         {
             if (runtime == null)
-                throw new NullReferenceException("AndroidLogcatRuntimeBase is null");
+                throw new ArgumentNullException("AndroidLogcatRuntimeBase is null");
             var settings = runtime.Settings;
             var userSettings = runtime.UserSettings;
             var selectedDevice = runtime.DeviceQuery.SelectedDevice;

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatMessageProviderTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatMessageProviderTests.cs
@@ -455,7 +455,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
         Assert.AreEqual(10.ToString(), logcat.RawEntries[0].message);
 
         m_Runtime.Settings.MaxFilteredMessageCount = 10;
-        AndroidLogcatUtilities.ApplySettings(m_Runtime.Settings, logcat);
+        AndroidLogcatUtilities.ApplySettings(m_Runtime, logcat);
         Assert.AreEqual(10, logcat.FilteredEntries.Count);
         Assert.AreEqual(20, logcat.RawEntries.Count);
         Assert.AreEqual(20.ToString(), logcat.FilteredEntries[0].message);
@@ -473,6 +473,14 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         logcat.Stop();
 
+        ShutdownRuntime();
+    }
+
+    [Test]
+    public void CanApplySettingsWithNullLogcat()
+    {
+        InitRuntime();
+        AndroidLogcatUtilities.ApplySettings(m_Runtime, null);
         ShutdownRuntime();
     }
 
@@ -508,7 +516,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         // Entry at index 2 will be stripped
         m_Runtime.Settings.MaxFilteredMessageCount = 10;
-        AndroidLogcatUtilities.ApplySettings(m_Runtime.Settings, logcat);
+        AndroidLogcatUtilities.ApplySettings(m_Runtime, logcat);
 
         entries = logcat.GetSelectedFilteredEntries(out minIdx, out maxIdx);
         Assert.AreEqual(1, entries.Count);

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatPackageTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatPackageTests.cs
@@ -24,20 +24,29 @@ internal class AndroidLogcatPackageTests : AndroidLogcatRuntimeTestBase
             }
 
             // All packages are alive, calling cleanup dead packages, shouldn't clean anything
-            m_Runtime.UserSettings.CleanupDeadPackagesForDevice(fakeDevice);
+            m_Runtime.UserSettings.CleanupDeadPackagesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
             var packages = m_Runtime.UserSettings.GetKnownPackages(fakeDevice);
             Assert.AreEqual(kPackagesToCreate, packages.Count);
 
             foreach (var p in packages)
                 p.SetExited();
 
-            m_Runtime.UserSettings.CleanupDeadPackagesForDevice(fakeDevice);
+            m_Runtime.UserSettings.CleanupDeadPackagesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
 
-            Assert.AreEqual(AndroidLogcatUserSettings.kMaxExitedPackages, packages.Count);
+            Assert.AreEqual(m_Runtime.Settings.MaxExitedPackagesToShow, packages.Count);
 
             // Check that recent packages are still there, only the old packages should be removed
             foreach (var p in packages)
                 Assert.IsTrue(p.processId > 5);
+
+            // Lower the number of max exited packages
+            m_Runtime.Settings.MaxExitedPackagesToShow = 4;
+            m_Runtime.UserSettings.CleanupDeadPackagesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
+            packages = m_Runtime.UserSettings.GetKnownPackages(fakeDevice);
+            Assert.AreEqual(m_Runtime.Settings.MaxExitedPackagesToShow, packages.Count);
+
+            foreach (var p in packages)
+                Assert.IsTrue(p.processId > 6);
         }
         finally
         {


### PR DESCRIPTION
### Purpose of PR
**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [X] Documentation update
- [X] Other (please describe) 

* Added Max Exited Packages in Preferences->Android Logcat Settings, which controls how many exited packages to show in package selection
![MaxExitedPackages](https://user-images.githubusercontent.com/568752/157466063-54a01c01-04a6-456d-a475-0f148528cf36.png)

* Added Known Issues documentation - where Android Logcat might work incorrectly if you have multiple instances of Editor running
![Doc](https://user-images.githubusercontent.com/568752/157465127-c1edc801-8d66-4b6e-9012-67d54b3be603.png)

### Checklist for PR maker
- [ ] Have you added a backport label? (if needed)
- [X] Have you updated the Changelog? _Each package has a `CHANGELOG.md` file_
- [ ] **Have you added or updated the Documentation to your PR? 

---
### Testing status
* **Existing or new automation tests - what automation was added, changed**
Expanded DeadPackagesAreCleanupCorrectly test
* **Detailed description of what testing was done, what projects were run**
    * Set Max Exited Packages to 3 in Preferences->Android Logcat Settings
    * Launched some app on Android
    * Selected it in Android Package
    * Exited the app
    * Repeat the step those 3 steps multiple times
    * Ensured that in Package selection there's only 3 Exited packages available
    * Set Max Exited Packages to 2 in Preferences->Android Logcat Settings
    * Ensured that in Package Selection there's only 2 items available
* **What environment did you test on?**
Windows, Google Pixel 2 XL with Android 11. But it really doesn't matter since this change doesn't depend on OS or android device.

