### PR TITLE
Add navigation through messages using arrows

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -18,8 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add setting for controlling how many exited packages to show in package selection.
  - Add doc about known issue where logcat might work incorrectly if there more than one Editor instance running.
  - You can now navigate through messages using arrow keys.
-
-### Fixes & Improvements.
  - Bump minimum Unity version support from 2019.2 to 2019.4
 
 ## [1.2.2] - 2021-04-21

--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fixed tiny issue, when right clicking on the log message, the tag and process id for context menu was being taken from the first selected item, now it will be taken from item which you're hovering on
  - Fixed issue, when right clicking on the log message with tag containing forward slash, the menu would be incorrectly displayed.
  - Fixed issue, where logcat package would freeze, if you would click Clear after disconnecting the device.
-
+ - You can now navigate through messages using arrow keys.
+ 
 ### Fixes & Improvements.
  - Bump minimum Unity version support from 2019.2 to 2019.4
 

--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Max Filtered Messages - controls how many filtered messages display on the list, you can remove the limit, but it might cause UI issues.
  - Fixed tiny issue, when right clicking on the log message, the tag and process id for context menu was being taken from the first selected item, now it will be taken from item which you're hovering on
  - Fixed issue, when right clicking on the log message with tag containing forward slash, the menu would be incorrectly displayed.
- - Fixed issue, where logcat package would freeze, if you would click Clear after disconnecting the device. - Add setting for controlling how many exited packages to show in package selection.
+ - Fixed issue, where logcat package would freeze, if you would click Clear after disconnecting the device. 
+ - Add setting for controlling how many exited packages to show in package selection.
  - Add doc about known issue where logcat might work incorrectly if there more than one Editor instance running.
  - You can now navigate through messages using arrow keys.
 

--- a/com.unity.mobile.android-logcat/Documentation~/LogControls.md
+++ b/com.unity.mobile.android-logcat/Documentation~/LogControls.md
@@ -3,11 +3,14 @@
 The log window contains multiple predefined columns, you can enable/disable them by right clicking on the columns.  
 ![Log Columns](images/log_columns.png)
 
-**Copy**  
+##### **Copy**
 The selected logs can be copied to the clipboard. You can right click on the messages and select **Copy**.
 
-**Save**  
+##### **Save**
 The selected logs can be saved to file. You can right click on the messages and select **Save Selection**.
 
-**Clear**  
+##### **Clear** 
 You can clear all the logs by clicking the **Clear** button on the toolbar.
+
+##### **Arrow Keys**
+You can use up and down arrow keys to navigate through log messages.

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
@@ -422,9 +422,8 @@ namespace Unity.Android.Logcat
 
         private static int s_DebuggingMessageId;
 
-        private void DbgAddLogLines()
+        private void DbgAddLogLines(int count)
         {
-            int count = 10000;
             var entries = new List<LogcatEntry>(count);
             for (int i = 0; i < count; i++)
             {
@@ -438,10 +437,13 @@ namespace Unity.Android.Logcat
         }
         internal void DoDebuggingGUI()
         {
+            if (GUILayout.Button("Add Log line", AndroidLogcatStyles.toolbarButton))
+            {
+                DbgAddLogLines(1);
+            }
             if (GUILayout.Button("Add Log lines", AndroidLogcatStyles.toolbarButton))
             {
-                DbgAddLogLines();
-
+                DbgAddLogLines(10000);
             }
             GUILayout.Label($"Raw: {m_RawLogEntries.Count} Filtered: {m_FilteredLogEntries.Count}");
         }

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatAutoScrollInfo.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatAutoScrollInfo.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEditor;
+
+namespace Unity.Android.Logcat
+{
+    internal class AutoScrollInfo
+    {
+        internal enum AutoScroll
+        {
+            None,
+            ScrollToEnd,
+            ScrollToSelectedItem
+        }
+
+        public AutoScroll Type { get; }
+
+        public int UserData { get; }
+
+        public AutoScrollInfo(AutoScroll scroll)
+        {
+            Type = scroll;
+        }
+
+        public AutoScrollInfo(AutoScroll scroll, int userData)
+        {
+            Type = scroll;
+            UserData = userData;
+        }
+
+        public static AutoScrollInfo None => new AutoScrollInfo(AutoScroll.None);
+        public static AutoScrollInfo ScrollToEnd => new AutoScrollInfo(AutoScroll.ScrollToEnd);
+    }
+}

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatAutoScrollInfo.cs.meta
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatAutoScrollInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 945a7acdc88009b4c9b14bbb29ba8163
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of PR
**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [X] Other (please describe) 

* **Description of the feature**
Add navigational controls for messages using arrow keys.
* **Links to screenshots, design docs, user docs, etc.**
* **Links to Jira/Fogbugz cases**
* **Halo effect**
none
* **Performance Impact**
none
* **Package requirements**
none

### Checklist for PR maker
- [ ] Have you added a backport label? (if needed)
- [X] Have you updated the Changelog? _Each package has a `CHANGELOG.md` file_
- [X] **Have you added or updated the Documentation to your PR?**
![arrowdocs](https://user-images.githubusercontent.com/568752/157664532-c836cc4d-deb5-4346-a366-d33f214f9db5.png)

---
### Testing status
* **Existing or new automation tests - what automation was added, changed**
No automated tests for this one
* **Detailed description of what testing was done, what projects were run**
Test following scenarios:
    * No messages are selected
    * Click up Arrow, the most bottom item will get selected and message window will scroll to it

    * No messages are selected
    * Click down Arrow, the most top item will get selected and message window will scroll to it

    * Play with down and up arrows, and see that message view scrolls to it

    * Make selection of two items with unselected items between them
    * Click up or down arrow, will deselect multiple items, and top or bottom item will get selected

* **What environment did you test on?**
Windows, Google Pixel 2 XL, Android 11, but it doesn't matter
* **Projects**
Used SampleProject1 from repo
