### PR TITLE
Hide API docs that the user shouldn't see

### DIFF
--- a/com.unity.mobile.android-logcat/Documentation~/filter.yml
+++ b/com.unity.mobile.android-logcat/Documentation~/filter.yml
@@ -1,0 +1,7 @@
+apiRules:
+  - exclude:
+      uidRegex: ^Global
+      type: Namespace
+  - exclude:
+      uidRegex: ^Unity\.Android\.Logcat
+      type: Namespace


### PR DESCRIPTION
### Purpose of PR
Updates the filter.yml to hides the following APIs:
- Global Namespace
	  - Android​Logcat​Dispatcher​Tests
	  - Android​Logcat​General​Tests
	  - Android​Logcat​Memory​Tests
	  - Android​Logcat​Net​Tests
	  - Android​Logcat​Stacktrace​Tests
	  - Android​Logcat​Tests​Setup
- Unity.​Android.​Logcat
	  - On​Load
	  - Requires​Android​Device​Attribute
	  - Workspace