### PR TITLE
Expose logcat API to device explorer

### DIFF
--- a/com.unity.mobile.android-logcat/Editor/AssemblyInfo.cs
+++ b/com.unity.mobile.android-logcat/Editor/AssemblyInfo.cs
@@ -3,3 +3,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.Mobile.AndroidLogcat.EditorTests")]
 [assembly: InternalsVisibleTo("Unity.Mobile.AndroidLogcat.IntegrationTests")]
 [assembly: InternalsVisibleTo("Unity.Mobile.AndroidLogcat.EditorPerformanceTests")]
+[assembly: InternalsVisibleTo("Unity.Mobile.DeviceExplorer.Editor")]


### PR DESCRIPTION
There's a little project called Device Explorer.

Android Logcat has a very good API for device selection and running ADB commands. 

Expose for Device Explorer

