### PR TITLE
Bump to 1.3.2

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.3.2] - 2022-04-12
 ### Fixes & Improvements
  - Fix integration tests not able to run on a specific build server configuration like Katana.
+ - Fix stacktrace resolving, when Unity uses NDK 23.
 
 ## [1.3.1] - 2022-04-11
 ### Fixes & Improvements.

--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.3.2] - 2022-04-11
+## [1.3.2] - 2022-04-12
 ### Fixes & Improvements
  - Fix integration tests not able to run on a specific build server configuration like Katana.
 

--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2022-04-11
+### Fixes & Improvements
+ - Fix integration tests not able to run on a specific build server configuration like Katana.
+
 ## [1.3.1] - 2022-04-11
 ### Fixes & Improvements.
  - Docs updated.

--- a/com.unity.mobile.android-logcat/Editor/AndroidTools/AndroidTools.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidTools/AndroidTools.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace Unity.Android.Logcat
@@ -8,13 +9,45 @@ namespace Unity.Android.Logcat
     internal class AndroidTools
     {
         private string m_NDKDirectory;
+        private Version m_NDKVersion;
         private string m_Addr2LinePath;
         private string m_NMPath;
         private string m_ReadElfPath;
         private AndroidBridge.ADB m_ADB;
 
+        internal Version NDKVersion
+        {
+            get
+            {
+                ResolvePathsIfNeeded();
+                return m_NDKVersion;
+            }
+        }
+
         internal AndroidTools()
         {
+        }
+
+        private static Version GetNDKVersion(string ndkPath)
+        {
+            var sourceProperties = Path.Combine(ndkPath, "source.properties");
+            if (!File.Exists(sourceProperties))
+                throw new Exception($"Couldn't acquire NDK version, '{sourceProperties}' was not found");
+
+            var contents = File.ReadAllText(sourceProperties);
+            var regex = new Regex(@"Pkg\.Revision\s*=\s*(?<version>\S+)");
+            var match = regex.Match(contents);
+            if (match.Success)
+            {
+                var versionText = match.Groups["version"].Value;
+                if (!Version.TryParse(versionText, out var version))
+                    throw new Exception($"Couldn't resolve version from '{sourceProperties}', the value was '{versionText}'");
+                return version;
+            }
+            else
+            {
+                throw new Exception($"Couldn't not find NDK version inside '{sourceProperties}', file contents\n:{contents}");
+            }
         }
 
         private void ResolvePathsIfNeeded()
@@ -22,27 +55,7 @@ namespace Unity.Android.Logcat
             string platformTag = "windows-x86_64";
             if (Application.platform != RuntimePlatform.WindowsEditor)
                 platformTag = "darwin-x86_64";
-#if UNITY_2019_3_OR_NEWER
             var ndkDirectory = AndroidBridge.AndroidExternalToolsSettings.ndkRootPath;
-#else
-            var directoriesToChecks = new[]
-            {
-                Path.GetFullPath(Path.Combine(Path.GetDirectoryName(AndroidBridge.ADB.GetInstance().GetADBPath()), @"..\..\NDK")),
-                UnityEditor.EditorPrefs.GetString("AndroidNdkRootR16b"),
-                System.Environment.GetEnvironmentVariable("ANDROID_NDK_ROOT")
-            };
-
-            var ndkDirectory = string.Empty;
-            foreach (var d in directoriesToChecks)
-            {
-                if (string.IsNullOrEmpty(d))
-                    continue;
-                if (!Directory.Exists(d))
-                    continue;
-                ndkDirectory = d;
-                break;
-            }
-#endif
             if (string.IsNullOrEmpty(ndkDirectory))
                 throw new Exception("Failed to locate NDK directory");
 
@@ -55,16 +68,24 @@ namespace Unity.Android.Logcat
 
             m_NDKDirectory = ndkDirectory;
 
-#if UNITY_2019_3_OR_NEWER
+            m_NDKVersion = GetNDKVersion(m_NDKDirectory);
+
             var binPath = Paths.Combine(m_NDKDirectory, "toolchains", "llvm", "prebuilt", platformTag, "bin");
             m_NMPath = Path.Combine(binPath, "llvm-nm");
-#else
-            var binPath = Paths.Combine(m_NDKDirectory, "toolchains", "aarch64-linux-android-4.9", "prebuilt", platformTag, "bin");
-            m_NMPath = Path.Combine(binPath, "aarch64-linux-android-nm");
-#endif
 
-            m_Addr2LinePath = Path.Combine(binPath, "aarch64-linux-android-addr2line");
-            m_ReadElfPath = Path.Combine(binPath, "aarch64-linux-android-readelf");
+            if (m_NDKVersion >= new Version(23, 1))
+            {
+                
+                m_Addr2LinePath = Path.Combine(binPath, "llvm-addr2line");
+                m_ReadElfPath = Path.Combine(binPath, "llvm-readelf");
+            }
+            else
+            {
+
+                m_Addr2LinePath = Path.Combine(binPath, "aarch64-linux-android-addr2line");
+                m_ReadElfPath = Path.Combine(binPath, "aarch64-linux-android-readelf");
+            }
+
             if (Application.platform == RuntimePlatform.WindowsEditor)
             {
                 m_Addr2LinePath += ".exe";

--- a/com.unity.mobile.android-logcat/Editor/AndroidTools/AndroidTools.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidTools/AndroidTools.cs
@@ -75,7 +75,7 @@ namespace Unity.Android.Logcat
 
             if (m_NDKVersion >= new Version(23, 1))
             {
-                
+
                 m_Addr2LinePath = Path.Combine(binPath, "llvm-addr2line");
                 m_ReadElfPath = Path.Combine(binPath, "llvm-readelf");
             }

--- a/com.unity.mobile.android-logcat/Tests/AndroidLogcatConditionals.cs
+++ b/com.unity.mobile.android-logcat/Tests/AndroidLogcatConditionals.cs
@@ -10,14 +10,18 @@ namespace Unity.Android.Logcat
         static OnLoad()
         {
             var runningOnYamato = Workspace.IsRunningOnYamato();
+            var runningOnKatana = Workspace.IsRunningOnKatana();
+            var runningOnBuildServer = Workspace.IsRunningOnBuildServer();
             var androidDeviceInfo = Workspace.GetAndroidDeviceInfo();
 
             Console.WriteLine($"Running On Yamato: {runningOnYamato}");
+            Console.WriteLine($"Running On Katana: {runningOnKatana}");
+            Console.WriteLine($"Running On Build Server: {runningOnBuildServer}");
             Console.WriteLine($"Android Device Info: {androidDeviceInfo}");
 
-            // Ignore test only if running on Yamato and device info is not available
+            // Ignore test only if running on Yamato or Katana and device info is not available
             // We always want our test to run when running locally
-            ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(nameof(RequiresAndroidDeviceAttribute), runningOnYamato && string.IsNullOrEmpty(androidDeviceInfo));
+            ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(nameof(RequiresAndroidDeviceAttribute), runningOnBuildServer && string.IsNullOrEmpty(androidDeviceInfo));
         }
     }
 

--- a/com.unity.mobile.android-logcat/Tests/AndroidLogcatWorkspace.cs
+++ b/com.unity.mobile.android-logcat/Tests/AndroidLogcatWorkspace.cs
@@ -13,6 +13,16 @@ namespace Unity.Android.Logcat
             return Environment.GetEnvironmentVariable("YAMATO_PROJECT_ID") != null;
         }
 
+        public static bool IsRunningOnKatana()
+        {
+            return Environment.GetEnvironmentVariable("UNITY_THISISABUILDMACHINE") == "1";
+        }
+
+        public static bool IsRunningOnBuildServer()
+        {
+            return IsRunningOnYamato() || IsRunningOnKatana();
+        }
+
         public static string GetAndroidDeviceInfo()
         {
             var result = Environment.GetEnvironmentVariable("ANDROID_DEVICE_CONNECTION");
@@ -23,7 +33,7 @@ namespace Unity.Android.Logcat
 
         public static string GetAritfactsPath()
         {
-            if (!Workspace.IsRunningOnYamato())
+            if (!Workspace.IsRunningOnBuildServer())
                 return Path.Combine(Application.dataPath, "../LocalTestResults");
 
             var result = Environment.GetEnvironmentVariable("ARTIFACTS_PATH");

--- a/com.unity.mobile.android-logcat/package.json
+++ b/com.unity.mobile.android-logcat/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.mobile.android-logcat",
     "displayName": "Android Logcat",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "unity": "2019.4",
     "description": "Android Logcat package provides support for:\n - Android log messages\n - Android application memory statistics\n - Android Screen Capture\n - Android Screen Recorder\n - Stacktrace Utility\n\nClick the 'View documentation' link above for more information.\n\nThe window can be accessed in Unity Editor via 'Window > Analysis > Android Logcat', or simply by pressing 'Alt+6' on Windows or 'Option+6' on macOS. \n\nMake sure to have Android module loaded and switch to Android build target in 'Build Settings' window if the menu doesn't exist.",
 	"keywords": ["Mobile", "Android", "Logcat"],


### PR DESCRIPTION
* Disable integration tests when running on Katana, but Android device is not available.
* CI showed that stacktrace resolving functionality stopped working, most likely due NDK23 update. Fixed it.