### PR TITLE
Remove redundent link from index page.

### DIFF
--- a/com.unity.mobile.android-logcat/Documentation~/index.md
+++ b/com.unity.mobile.android-logcat/Documentation~/index.md
@@ -1,5 +1,3 @@
 # Android Logcat
 
 The Android Logcat Package displays messages such as stack traces and [logs](https://docs.unity3d.com/ScriptReference/Debug.Log.html) from an Android device in the Unity Editor.
-
-For more information, see [Android Logcat](https://docs.unity3d.com/Packages/com.unity.mobile.android-logcat@latest/index.html).


### PR DESCRIPTION
### Purpose of PR

Removes a redundant link from the index page. I think this was a copy/paste error at some point when I brought some wording/content from the main manual into the Google Doc.