### PR TITLE
Fix expected references for Editor Assemblies compiled against NET Standard

### DIFF
--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatNetTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatNetTests.cs
@@ -67,7 +67,7 @@ public class AndroidLogcatNetTests
                 "UnityEditor.CoreModule",
             });
         }
-        
+
 #else
         var expectedReferences = new List<string>(new[]
         {

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatNetTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatNetTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEditor.Compilation;
 using Assembly = System.Reflection.Assembly;
 
@@ -33,6 +34,41 @@ public class AndroidLogcatNetTests
     {
         var logcatAssembly = GetLogcatAssembly();
 
+#if UNITY_2023_1_OR_NEWER
+        var expectedReferences = new List<string>();
+
+        if (PlayerSettings.GetEditorAssembliesCompatibilityLevel() == EditorAssembliesCompatibilityLevel.NET_Standard)
+        {
+            expectedReferences.AddRange(new[]
+            {
+                "netstandard",
+                "UnityEditor.CoreModule",
+                "UnityEngine.CoreModule",
+                "UnityEngine.IMGUIModule",
+                "UnityEngine.VideoModule",
+                "UnityEngine.TextRenderingModule",
+                "UnityEngine.ImageConversionModule",
+                "UnityEngine.JSONSerializeModule",
+            });
+        }
+        else
+        {
+            expectedReferences.AddRange(new[]
+            {
+                "mscorlib",
+                "System",
+                "UnityEngine.IMGUIModule",
+                "UnityEngine.CoreModule",
+                "UnityEngine.VideoModule",
+                "UnityEngine.TextRenderingModule",
+                "System.Core",
+                "UnityEngine.ImageConversionModule",
+                "UnityEngine.JSONSerializeModule",
+                "UnityEditor.CoreModule",
+            });
+        }
+        
+#else
         var expectedReferences = new List<string>(new[]
         {
             "mscorlib",
@@ -50,6 +86,7 @@ public class AndroidLogcatNetTests
             "UnityEditor",
 #endif
         });
+#endif
 
         var referencedCount = expectedReferences.ToDictionary(s => s, s => 0);
 

--- a/com.unity.mobile.android-logcat/Tests/Integration/AndroidLogcatIntegrationTestBase.cs
+++ b/com.unity.mobile.android-logcat/Tests/Integration/AndroidLogcatIntegrationTestBase.cs
@@ -111,7 +111,7 @@ internal class AndroidLogcatIntegrationTestBase
 
     protected static void Log(string message)
     {
-        Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, message);
+        Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, "{0}", message);
     }
 
     protected static string GetOrCreateArtifactsPath()


### PR DESCRIPTION
Recreated PR from here https://github.com/Unity-Technologies/com.unity.mobile.logcat/pull/164

The purpose of this PR is to fix one of the tests' expected references when the Editor Assemblies are compiled against NET Standard.

This feature was added in 2023.1