### PR TITLE
Improve device selection dropdown

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix stacktrace resolve regex for entry like '  #15  pc 0x0000000000a0de84  /data/app/com.DefaultCompany.NativeRuntimeException1-eStyrW-dxxC0QfRH6veLhA==/lib/arm64/libunity.so'. Reset regex to apply the fix
  - Added inputs window - Tools->Window->Inputs, where you can easily inject keyboard/text input on to android device.
  - Add Scroll option for messages which allows you to explicitly to always scroll to end without automatic logic.
+ - Device selection dropdown will contain device name + id, if device name is not available, only id will be displayed.
  
 ## [1.3.2] - 2022-04-12
 ### Fixes & Improvements

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatDevice.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatDevice.cs
@@ -198,7 +198,7 @@ namespace Unity.Android.Logcat
                 {
                     if (m_DisplayName != null)
                         return m_DisplayName;
-                    m_DisplayName = string.Format("{0} {1} (version: {2}, abi: {3}, sdk: {4}, id: {5})", Manufacturer, Model, OSVersion, ABI, APILevel, Id);
+                    m_DisplayName = $"{Manufacturer} {Model} (version: {OSVersion}, abi: {ABI}, sdk: {APILevel}, id: {Id})";
                     return m_DisplayName;
                 }
             }
@@ -208,10 +208,11 @@ namespace Unity.Android.Logcat
         {
             get
             {
+                var shortName = Manufacturer.Length > 0 ? $"{Manufacturer} {Model} ({Id})" : Id;
                 if (m_Device == null || State != DeviceState.Connected)
-                    return Id + " (" + State.ToString() + ")";
+                    return $"{shortName} ({State})";
                 else
-                    return Id;
+                    return shortName;
             }
         }
 

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatScreenCaptureWindow.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatScreenCaptureWindow.cs
@@ -186,7 +186,7 @@ namespace Unity.Android.Logcat
 
         private void DoSelectedDeviceGUI()
         {
-            var deviceNames = m_Devices.Select(m => new GUIContent(m.Id)).ToArray();
+            var deviceNames = m_Devices.Select(m => new GUIContent(m.ShortDisplayName)).ToArray();
             if (deviceNames.Length == 0)
             {
                 m_SelectedDeviceIdx = 0;


### PR DESCRIPTION
## **Please read and consider what information you want to pass on to people reviewing this PR**

### Purpose of PR
**Type of change:**
- [X] Improvement

* **Description of the feature**
Device dropdown instead of ids, will contain human readable device names
* **Links to screenshots, design docs, user docs, etc.**
![NewDeviceSelection](https://github.com/Unity-Technologies/com.unity.mobile.logcat/assets/568752/979fe096-9df2-4804-ab80-415bb46b8a09)
* **Links to Jira/Fogbugz cases**
https://jira.unity3d.com/browse/PLAT-5328

---
### Testing status
* **Existing or new automation tests - what automation was added, changed**
Cannot be tested in automated way.

* **Detailed description of what testing was done, what projects were run**
* Scenario 1:
    * Connected two authorized devices - Google Pixel 2 and Oppo, saw that device drop down now says Google Pixel and Oppo
* Scenario 2:
    * Connected one authorized device - Google Pixel 2 and one unauthorized - Oppo, since we cannot get device name when it's unauthorized, the dropdown displays only device id + status
* Scenario 3:
    * Connected Google Pixel 2 via USB + connected same device via Wifi, checked that dropdown contains two same entries, but also had id in brackets

