### PR TITLE
https://jira.unity3d.com/browse/ALB-22 Fix issue where logs would be sometimes not displayed

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2024-12-12
+### Fixes & Improvements
+ - Logcat package will now detect if logs with specific tag are disabled on the device (this was causing messages not to be displayed), and if so, will provide an information message providing a button to fix such behavior.
+ 
 ## [1.4.0] - 2023-11-21
 ### Fixes & Improvements
  - Fix stacktrace resolve regex for entry like '  #15  pc 0x0000000000a0de84  /data/app/com.DefaultCompany.NativeRuntimeException1-eStyrW-dxxC0QfRH6veLhA==/lib/arm64/libunity.so'. Reset regex to apply the fix

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatConsoleWindow.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatConsoleWindow.cs
@@ -777,6 +777,8 @@ namespace Unity.Android.Logcat
             StopLogCat();
 
             StartLogcat();
+
+            CollectTagPrioritiesFromDevice();
         }
 
         private void StartLogcat()

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatMessagesViews.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatMessagesViews.cs
@@ -42,6 +42,7 @@ namespace Unity.Android.Logcat
         private Vector2 m_ScrollPosition = Vector2.zero;
         private float m_MaxLogEntryWidth = 0.0f;
         private static readonly List<LogcatEntry> kNoEntries = new List<LogcatEntry>();
+        private Dictionary<string, Priority> m_TagPriorityOnDevice = new Dictionary<string, Priority>();
 
         public IReadOnlyList<LogcatEntry> FilteredEntries
         {
@@ -67,6 +68,23 @@ namespace Unity.Android.Logcat
 
         private ScrollData m_ScrollData = new ScrollData();
         private float doubleClickStart = -1;
+
+        void CollectTagPrioritiesFromDevice()
+        {
+            m_TagPriorityOnDevice.Clear();
+            var d = m_Runtime.DeviceQuery.SelectedDevice;
+            if (d == null && d.State != IAndroidLogcatDevice.DeviceState.Connected)
+                return;
+
+            var tags = m_Runtime.UserSettings.Tags.GetSelectedTags(true);
+            if (tags == null || tags.Length == 0)
+                tags = AndroidLogcatTags.DefaultTagNames;
+
+            foreach (var tag in tags)
+            {
+                m_TagPriorityOnDevice[tag] = d.GetTagPriority(tag);
+            }
+        }
 
         private ColumnData[] Columns
         {
@@ -209,6 +227,45 @@ namespace Unity.Android.Logcat
 
             DoMouseEventsForHeaderToolbar(fullHeaderRect);
             return requestRepaint;
+        }
+
+        private bool DoGUITagsValidation()
+        {
+            var result = false;
+            var message = new StringBuilder();
+            var fixCommand = new StringBuilder();
+            foreach (var t in m_TagPriorityOnDevice)
+            {
+                if (t.Value == Priority.Verbose)
+                    continue;
+                message.AppendLine($" Tag '{t.Key}' has priority '{t.Value}'");
+                fixCommand.AppendLine($"  adb shell setprop log.tag.{t.Key} {Priority.Verbose}");
+            }
+
+            // No tags to fix
+            if (message.Length == 0)
+                return false;
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.HelpBox($"Some tags have invalid priorities, this can cause messages not to be displayed for these tags:\n{message}",
+                MessageType.Error);
+            var opts = new[] { GUILayout.Height(38), GUILayout.ExpandWidth(false) };
+            var d = m_Runtime.DeviceQuery.SelectedDevice;
+
+            if (GUILayout.Button(new GUIContent("Fix Me", $"The following commands will be executed:\n{fixCommand}"), opts) && d != null)
+            {
+                foreach (var t in m_TagPriorityOnDevice)
+                {
+                    if (t.Value == Priority.Verbose)
+                        continue;
+                    d.SetTagPriority(t.Key, Priority.Verbose);
+                    result = true;
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+            if (result)
+                CollectTagPrioritiesFromDevice();
+            return result;
         }
 
         private void MenuSelectionColumns(object userData, string[] options, int selected)
@@ -709,7 +766,10 @@ namespace Unity.Android.Logcat
 
         public bool DoMessageView()
         {
-            return DoGUIHeader() | DoGUIEntries();
+            var repaint = DoGUIHeader();
+            repaint |= DoGUITagsValidation();
+            repaint |= DoGUIEntries();
+            return repaint;
         }
 
         private void SaveToFile(IEnumerable<LogcatEntry> logEntries)

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatMessagesViews.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatMessagesViews.cs
@@ -253,7 +253,7 @@ namespace Unity.Android.Logcat
             EditorGUILayout.HelpBox($"Some tags on the device '{d.ShortDisplayName}' have invalid priorities, this can cause messages for these tags not to be displayed:\n{message}",
                 MessageType.Error);
             var opts = new[] { GUILayout.Height(38), GUILayout.ExpandWidth(false) };
-            
+
             if (GUILayout.Button(new GUIContent("Fix Me", $"The following commands will be executed:\n{fixCommand}"), opts) && d != null)
             {
                 foreach (var t in m_TagPriorityOnDevice)

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatMessagesViews.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatMessagesViews.cs
@@ -231,6 +231,9 @@ namespace Unity.Android.Logcat
 
         private bool DoGUITagsValidation()
         {
+            var d = m_Runtime.DeviceQuery.SelectedDevice;
+            if (d == null)
+                return false;
             var result = false;
             var message = new StringBuilder();
             var fixCommand = new StringBuilder();
@@ -247,11 +250,10 @@ namespace Unity.Android.Logcat
                 return false;
 
             EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.HelpBox($"Some tags have invalid priorities, this can cause messages not to be displayed for these tags:\n{message}",
+            EditorGUILayout.HelpBox($"Some tags on the device '{d.ShortDisplayName}' have invalid priorities, this can cause messages for these tags not to be displayed:\n{message}",
                 MessageType.Error);
             var opts = new[] { GUILayout.Height(38), GUILayout.ExpandWidth(false) };
-            var d = m_Runtime.DeviceQuery.SelectedDevice;
-
+            
             if (GUILayout.Button(new GUIContent("Fix Me", $"The following commands will be executed:\n{fixCommand}"), opts) && d != null)
             {
                 foreach (var t in m_TagPriorityOnDevice)

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatSessionSettings.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatSessionSettings.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.Android.Logcat
+{
+    /// <summary>
+    /// Settings which only persist during the Editor session.
+    /// </summary>
+    internal static class AndroidLogcatSessionSettings
+    {
+        private static string GetName(string name)
+        {
+            return $"{nameof(AndroidLogcatSessionSettings)}.{name}";
+        }
+
+        internal static bool ShowTagPriorityErrors
+        {
+            set => SessionState.SetBool(GetName(nameof(ShowTagPriorityErrors)), value);
+            get => SessionState.GetBool(GetName(nameof(ShowTagPriorityErrors)), true);
+        }
+    }
+}

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatSessionSettings.cs.meta
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatSessionSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f80cf83681b2a94ca4a4396f0d0f690
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatTags.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatTags.cs
@@ -17,6 +17,10 @@ namespace Unity.Android.Logcat
     [Serializable]
     internal class AndroidLogcatTags
     {
+        internal static readonly string TagNameUnity = "Unity";
+        internal static readonly string TagNameCrash = "CRASH";
+        internal static readonly string[] DefaultTagNames = new[] { TagNameUnity, TagNameCrash };
+
         [SerializeField]
         private List<TagInformation> m_Entries = new List<TagInformation>(
             new[]
@@ -26,8 +30,8 @@ namespace Unity.Android.Logcat
                 new TagInformation() { Name = string.Empty, Selected = false },
                 new TagInformation() { Name = "Tag Control...", Selected = false },
                 new TagInformation() { Name = string.Empty, Selected = false },
-                new TagInformation() { Name = "Unity", Selected = false },
-                new TagInformation() { Name = "CRASH", Selected = false },
+                new TagInformation() { Name = TagNameUnity, Selected = false },
+                new TagInformation() { Name = TagNameCrash, Selected = false },
             });
 
         public event Action TagSelectionChanged;

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatFakeDevice.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatFakeDevice.cs
@@ -28,6 +28,17 @@ internal abstract class AndroidLogcatFakeDevice : IAndroidLogcatDevice
 
     internal override string ShortDisplayName => throw new NotImplementedException();
 
+    internal override Priority GetTagPriority(string tag)
+    {
+        // TODO
+        throw new NotImplementedException();
+    }
+
+    internal override void SetTagPriority(string tag, Priority priority)
+    {
+        throw new NotImplementedException();
+    }
+
     internal AndroidLogcatFakeDevice(string deviceId)
     {
         m_DeviceId = deviceId;

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatFakeDevice.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatFakeDevice.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 using Unity.Android.Logcat;
 
 internal abstract class AndroidLogcatFakeDevice : IAndroidLogcatDevice
 {
     private string m_DeviceId;
+    Dictionary<string, string> m_TagPriorities = new Dictionary<string, string>();
+
     internal override string Manufacturer
     {
         get { return "Undefined"; }
@@ -28,15 +31,16 @@ internal abstract class AndroidLogcatFakeDevice : IAndroidLogcatDevice
 
     internal override string ShortDisplayName => throw new NotImplementedException();
 
-    internal override Priority GetTagPriority(string tag)
+    protected override string GetTagPriorityAsString(string tag)
     {
-        // TODO
-        throw new NotImplementedException();
+        if (m_TagPriorities.TryGetValue(tag, out var priority))
+            return priority;
+        return string.Empty;
     }
 
-    internal override void SetTagPriority(string tag, Priority priority)
+    protected override void SetTagPriorityAsString(string tag, string priority)
     {
-        throw new NotImplementedException();
+        m_TagPriorities[tag] = priority;
     }
 
     internal AndroidLogcatFakeDevice(string deviceId)

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatGeneralTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatGeneralTests.cs
@@ -50,4 +50,18 @@ root      279   1     24908  908   20    0     0     0     ffffffff 00000000 S /
         Assert.AreEqual("/test/thermal-daemon", AndroidLogcatUtilities.ProcessOutputFromPS(android90Output2));
         Assert.AreEqual("/system/bin/netd", AndroidLogcatUtilities.ProcessOutputFromPS(android50Output));
     }
+
+    [Test]
+    public void CanSetGetTagPriorities()
+    {
+        var device = new AndroidLogcatFakeDevice90("Fake90");
+        var builtinTags = AndroidLogcatTags.DefaultTagNames;
+        foreach (var b in builtinTags)
+        {
+            Assert.AreEqual(Priority.Verbose, device.GetTagPriority(b));
+
+            device.SetTagPriority(b, Priority.Error);
+            Assert.AreEqual(Priority.Error, device.GetTagPriority(b));
+        }
+    }
 }

--- a/com.unity.mobile.android-logcat/package.json
+++ b/com.unity.mobile.android-logcat/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.mobile.android-logcat",
     "displayName": "Android Logcat",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "unity": "2021.3",
     "description": "Android Logcat package provides support for:\n - Android log messages\n - Android application memory statistics\n - Input injection\n - Android Screen Capture\n - Android Screen Recorder\n - Stacktrace Utility\n\nClick the 'View documentation' link above for more information.\n\nThe window can be accessed in Unity Editor via 'Window > Analysis > Android Logcat', or simply by pressing 'Alt+6' on Windows or 'Option+6' on macOS. \n\nMake sure to have Android module loaded and switch to Android build target in 'Build Settings' window if the menu doesn't exist.",
 	"keywords": ["Mobile", "Android", "Logcat"],


### PR DESCRIPTION
## **Please read and consider what information you want to pass on to people reviewing this PR**

### Purpose of PR
**Type of change:**
- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe) 

* **Description of the feature**

On some devices, device manufacturers where disabling logs with "Unity" tags, this was leaving users puzzling why Unity logs were not displayed. This PR adds a fix/improvement where logcat will check if log of specific tag is disabled and if so, will provide a button to fix that. See picture
![Error](https://github.com/Unity-Technologies/com.unity.mobile.logcat/assets/568752/12e01d16-a8ed-47e8-9a1b-530ca3047a67)


* **Links to Jira/Fogbugz cases**
* https://jira.unity3d.com/browse/ALB-22

### Checklist for PR maker
- [ ] Have you added a backport label? (if needed)
- [X] Have you updated the Changelog? _Each package has a `CHANGELOG.md` file_
- [ ] **Have you added or updated the Documentation to your PR?** _When you add a new feature, change a property name, or change the behaviour of a feature, it's best practice to include related documentation changes in the same PR_
---
### Testing status
* Add tiny automated test
* Manually tested the following scenario:
    * adb shell setprop log.tag.Unity ERROR
    * Tried logging something with Debug.Log, saw that nothing is picked up by logcat
    * Clicked 'Fix Me' in logcat window
    * Tried logging with Debug.Log again, the message will appear now
 