### PR TITLE
Fix tag filtering

### DIFF
--- a/TestProjects/SampleProject1/Packages/manifest.json
+++ b/TestProjects/SampleProject1/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.ide.visualstudio": "2.0.16",
+    "com.unity.ide.visualstudio": "2.0.17",
     "com.unity.mobile.android-logcat": "file:../../../com.unity.mobile.android-logcat",
     "com.unity.package-manager-doctools": "1.1.1-preview.5",
     "com.unity.test-framework": "1.1.31",

--- a/TestProjects/SampleProject1/ProjectSettings/ProjectSettings.asset
+++ b/TestProjects/SampleProject1/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 17
+  serializedVersion: 23
   productGUID: 9e0d97b4e9f2b244ab561a1639bc49cd
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -49,11 +49,12 @@ PlayerSettings:
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
   m_MTRendering: 1
+  mipStripping: 0
+  numberOfMipsStripped: 0
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
-  iosAppInBackgroundBehavior: 0
-  displayResolutionDialog: 1
+  iosUseCustomAppBackgroundBehavior: 0
   iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
   allowedAutorotateToPortraitUpsideDown: 1
@@ -67,6 +68,12 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 1
   androidUseSwappy: 0
   androidBlitType: 0
+  androidResizableWindow: 0
+  androidDefaultWindowWidth: 1920
+  androidDefaultWindowHeight: 1080
+  androidMinimumWindowWidth: 400
+  androidMinimumWindowHeight: 300
+  androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1
@@ -85,7 +92,6 @@ PlayerSettings:
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
-  graphicsJobs: 0
   xboxPIXTextureCapture: 0
   xboxEnableAvatar: 0
   xboxEnableKinect: 0
@@ -93,7 +99,6 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  graphicsJobMode: 0
   fullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
@@ -106,6 +111,7 @@ PlayerSettings:
   xboxOneMonoLoggingLevel: 0
   xboxOneLoggingLevel: 1
   xboxOneDisableEsram: 0
+  xboxOneEnableTypeOptimization: 0
   xboxOnePresentImmediateThreshold: 0
   switchQueueCommandMemory: 0
   switchQueueControlMemory: 0
@@ -113,7 +119,15 @@ PlayerSettings:
   switchNVNShaderPoolsGranularity: 33554432
   switchNVNDefaultPoolsGranularity: 16777216
   switchNVNOtherPoolsGranularity: 16777216
+  switchNVNMaxPublicTextureIDCount: 0
+  switchNVNMaxPublicSamplerIDCount: 0
+  stadiaPresentMode: 0
+  stadiaTargetFramerate: 0
+  vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
+  vulkanEnablePreTransform: 0
+  vulkanEnableLateAcquireNextImage: 0
+  vulkanEnableCommandBufferRecycling: 1
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -128,44 +142,27 @@ PlayerSettings:
   xboxOneDisableKinectGpuReservation: 0
   xboxOneEnable7thCore: 0
   vrSettings:
-    cardboard:
-      depthFormat: 0
-      enableTransitionView: 0
-    daydream:
-      depthFormat: 0
-      useSustainedPerformanceMode: 0
-      enableVideoLayer: 0
-      useProtectedVideoMemory: 0
-      minimumSupportedHeadTracking: 0
-      maximumSupportedHeadTracking: 1
-    hololens:
-      depthFormat: 1
-      depthBufferSharingEnabled: 0
-    lumin:
-      depthFormat: 0
-      frameTiming: 2
-      enableGLCache: 0
-      glCacheMaxBlobSize: 524288
-      glCacheMaxFileSize: 8388608
-    oculus:
-      sharedDepthBuffer: 0
-      dashSupport: 0
-      lowOverheadMode: 0
     enable360StereoCapture: 0
   isWsaHolographicRemotingEnabled: 0
-  protectGraphicsMemory: 0
   enableFrameTimingStats: 0
+  enableOpenGLProfilerGPURecorders: 1
   useHDRDisplay: 0
+  D3DHDRBitDepth: 0
   m_ColorGamuts: 00000000
   targetPixelDensity: 30
   resolutionScalingMode: 0
+  resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Android: com.Company.AndroidLogcatSample
-  buildNumber: {}
+    Android: com.Unity.AndroidLogcatSample
+  buildNumber:
+    Standalone: 0
+    iPhone: 0
+    tvOS: 0
+  overrideDefaultApplicationIdentifier: 0
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 16
+  AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -180,32 +177,16 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 9.0
+  iOSTargetOSVersionString: 11.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 9.0
+  tvOSTargetOSVersionString: 11.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
   uIStatusBarHidden: 1
   uIExitOnSuspend: 0
   uIStatusBarStyle: 0
-  iPhoneSplashScreen: {fileID: 0}
-  iPhoneHighResSplashScreen: {fileID: 0}
-  iPhoneTallHighResSplashScreen: {fileID: 0}
-  iPhone47inSplashScreen: {fileID: 0}
-  iPhone55inPortraitSplashScreen: {fileID: 0}
-  iPhone55inLandscapeSplashScreen: {fileID: 0}
-  iPhone58inPortraitSplashScreen: {fileID: 0}
-  iPhone58inLandscapeSplashScreen: {fileID: 0}
-  iPadPortraitSplashScreen: {fileID: 0}
-  iPadHighResPortraitSplashScreen: {fileID: 0}
-  iPadLandscapeSplashScreen: {fileID: 0}
-  iPadHighResLandscapeSplashScreen: {fileID: 0}
-  iPhone65inPortraitSplashScreen: {fileID: 0}
-  iPhone65inLandscapeSplashScreen: {fileID: 0}
-  iPhone61inPortraitSplashScreen: {fileID: 0}
-  iPhone61inLandscapeSplashScreen: {fileID: 0}
   appleTVSplashScreen: {fileID: 0}
   appleTVSplashScreen2x: {fileID: 0}
   tvOSSmallIconLayers: []
@@ -233,15 +214,17 @@ PlayerSettings:
   iOSLaunchScreeniPadFillPct: 100
   iOSLaunchScreeniPadSize: 100
   iOSLaunchScreeniPadCustomXibPath: 
-  iOSUseLaunchScreenStoryboard: 0
   iOSLaunchScreenCustomStoryboardPath: 
+  iOSLaunchScreeniPadCustomStoryboardPath: 
   iOSDeviceRequirements: []
   iOSURLSchemes: []
+  macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
   metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 0
+  iosCopyPluginsCodeInsteadOfSymlink: 0
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
@@ -251,10 +234,19 @@ PlayerSettings:
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
   appleEnableProMotion: 0
+  shaderPrecisionModel: 0
   clonedFromGUID: c0afd0d1d80e3634a9dac47e8a0426ea
   templatePackageId: com.unity.template.3d@1.0.3
   templateDefaultScene: Assets/Scenes/SampleScene.unity
+  useCustomMainManifest: 0
+  useCustomLauncherManifest: 0
+  useCustomMainGradleTemplate: 0
+  useCustomLauncherGradleManifest: 0
+  useCustomBaseGradleTemplate: 0
+  useCustomGradlePropertiesTemplate: 0
+  useCustomProguardFile: 0
   AndroidTargetArchitectures: 1
+  AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: '{inproject}: '
@@ -271,11 +263,106 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
+  chromeosInputEmulation: 1
+  AndroidMinifyWithR8: 0
+  AndroidMinifyRelease: 0
+  AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  resolutionDialogBanner: {fileID: 0}
   m_BuildTargetIcons: []
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: Android
+    m_Icons:
+    - m_Textures: []
+      m_Width: 432
+      m_Height: 432
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 324
+      m_Height: 324
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 216
+      m_Height: 216
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 162
+      m_Height: 162
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 108
+      m_Height: 108
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 81
+      m_Height: 81
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 0
+      m_SubKind: 
   m_BuildTargetBatching:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
@@ -292,16 +379,59 @@ PlayerSettings:
   - m_BuildTarget: WebGL
     m_StaticBatching: 0
     m_DynamicBatching: 0
+  m_BuildTargetShaderSettings: []
+  m_BuildTargetGraphicsJobs:
+  - m_BuildTarget: WindowsStandaloneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: MacStandaloneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: LinuxStandaloneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: AndroidPlayer
+    m_GraphicsJobs: 0
+  - m_BuildTarget: iOSSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: PS4Player
+    m_GraphicsJobs: 0
+  - m_BuildTarget: PS5Player
+    m_GraphicsJobs: 0
+  - m_BuildTarget: XboxOnePlayer
+    m_GraphicsJobs: 0
+  - m_BuildTarget: GameCoreXboxOneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: GameCoreScarlettSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: Switch
+    m_GraphicsJobs: 0
+  - m_BuildTarget: WebGLSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: MetroSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: AppleTVSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: BJMSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: LuminSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: CloudRendering
+    m_GraphicsJobs: 0
+  - m_BuildTarget: EmbeddedLinux
+    m_GraphicsJobs: 0
+  m_BuildTargetGraphicsJobMode:
+  - m_BuildTarget: PS4Player
+    m_GraphicsJobMode: 0
+  - m_BuildTarget: XboxOnePlayer
+    m_GraphicsJobMode: 0
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: AndroidPlayer
     m_APIs: 0b00000008000000
-    m_Automatic: 1
+    m_Automatic: 0
   - m_BuildTarget: iOSSupport
     m_APIs: 10000000
     m_Automatic: 1
   - m_BuildTarget: AppleTVSupport
     m_APIs: 10000000
-    m_Automatic: 0
+    m_Automatic: 1
   - m_BuildTarget: WebGLSupport
     m_APIs: 0b000000
     m_Automatic: 1
@@ -311,10 +441,11 @@ PlayerSettings:
     m_Devices:
     - Oculus
     - OpenVR
+  m_DefaultShaderChunkSizeInMB: 16
+  m_DefaultShaderChunkCount: 0
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
   openGLRequireES32: 0
-  vuforiaEnabled: 0
   m_TemplateCustomTags: {}
   mobileMTRendering:
     Android: 1
@@ -322,6 +453,8 @@ PlayerSettings:
     tvOS: 1
   m_BuildTargetGroupLightmapEncodingQuality: []
   m_BuildTargetGroupLightmapSettings: []
+  m_BuildTargetNormalMapEncoding: []
+  m_BuildTargetDefaultTextureCompressionFormat: []
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
@@ -331,12 +464,16 @@ PlayerSettings:
   cameraUsageDescription: 
   locationUsageDescription: 
   microphoneUsageDescription: 
+  bluetoothUsageDescription: 
+  switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144
   switchSocketAllocatorPoolSize: 128
   switchSocketConcurrencyLimit: 14
   switchScreenResolutionBehavior: 2
   switchUseCPUProfiler: 0
+  switchUseGOLDLinker: 0
+  switchLTOSetting: 0
   switchApplicationID: 0x01004b9000490000
   switchNSODependencies: 
   switchTitleNames_0: 
@@ -354,6 +491,7 @@ PlayerSettings:
   switchTitleNames_12: 
   switchTitleNames_13: 
   switchTitleNames_14: 
+  switchTitleNames_15: 
   switchPublisherNames_0: 
   switchPublisherNames_1: 
   switchPublisherNames_2: 
@@ -369,6 +507,7 @@ PlayerSettings:
   switchPublisherNames_12: 
   switchPublisherNames_13: 
   switchPublisherNames_14: 
+  switchPublisherNames_15: 
   switchIcons_0: {fileID: 0}
   switchIcons_1: {fileID: 0}
   switchIcons_2: {fileID: 0}
@@ -384,6 +523,7 @@ PlayerSettings:
   switchIcons_12: {fileID: 0}
   switchIcons_13: {fileID: 0}
   switchIcons_14: {fileID: 0}
+  switchIcons_15: {fileID: 0}
   switchSmallIcons_0: {fileID: 0}
   switchSmallIcons_1: {fileID: 0}
   switchSmallIcons_2: {fileID: 0}
@@ -399,6 +539,7 @@ PlayerSettings:
   switchSmallIcons_12: {fileID: 0}
   switchSmallIcons_13: {fileID: 0}
   switchSmallIcons_14: {fileID: 0}
+  switchSmallIcons_15: {fileID: 0}
   switchManualHTML: 
   switchAccessibleURLs: 
   switchLegalInformation: 
@@ -430,6 +571,7 @@ PlayerSettings:
   switchRatingsInt_9: 0
   switchRatingsInt_10: 0
   switchRatingsInt_11: 0
+  switchRatingsInt_12: 0
   switchLocalCommunicationIds_0: 
   switchLocalCommunicationIds_1: 
   switchLocalCommunicationIds_2: 
@@ -460,6 +602,12 @@ PlayerSettings:
   switchSocketInitializeEnabled: 1
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
+  switchUseNewStyleFilepaths: 0
+  switchUseLegacyFmodPriorities: 1
+  switchUseMicroSleepForYield: 1
+  switchEnableRamDiskSupport: 0
+  switchMicroSleepForYieldTime: 25
+  switchRamDiskSpaceSize: 12
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -486,6 +634,7 @@ PlayerSettings:
   ps4ShareFilePath: 
   ps4ShareOverlayImagePath: 
   ps4PrivacyGuardImagePath: 
+  ps4ExtraSceSysFile: 
   ps4NPtitleDatPath: 
   ps4RemotePlayKeyAssignment: -1
   ps4RemotePlayKeyMappingDir: 
@@ -511,6 +660,7 @@ PlayerSettings:
   ps4UseResolutionFallback: 0
   ps4ReprojectionSupport: 0
   ps4UseAudio3dBackend: 0
+  ps4UseLowGarlicFragmentationMode: 1
   ps4SocialScreenEnabled: 0
   ps4ScriptOptimizationLevel: 0
   ps4Audio3dVirtualSpeakerCount: 14
@@ -527,8 +677,12 @@ PlayerSettings:
   ps4disableAutoHideSplash: 0
   ps4videoRecordingFeaturesUsed: 0
   ps4contentSearchFeaturesUsed: 0
+  ps4CompatibilityPS5: 0
+  ps4AllowPS5Detection: 0
+  ps4GPU800MHz: 1
   ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
+  ps4attribVROutputEnabled: 0
   monoEnv: 
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
@@ -545,19 +699,27 @@ PlayerSettings:
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
   webGLCompressionFormat: 1
+  webGLWasmArithmeticExceptions: 0
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
-  webGLWasmStreaming: 0
+  webGLDecompressionFallback: 0
+  webGLPowerPreference: 2
   scriptingDefineSymbols: {}
+  additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
+  suppressCommonWarnings: 1
   allowUnsafeCode: 0
+  useDeterministicCompilation: 1
+  enableRoslynAnalyzers: 1
+  selectedPlatform: 2
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 0
+  assemblyVersionValidation: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform:
     Android: 6
@@ -590,6 +752,7 @@ PlayerSettings:
   metroFTAName: 
   metroFTAFileTypes: []
   metroProtocolName: 
+  vcxProjDefaultLanguage: 
   XboxOneProductId: 
   XboxOneUpdateKey: 
   XboxOneSandboxId: 
@@ -608,18 +771,16 @@ PlayerSettings:
   XboxOneCapability: []
   XboxOneGameRating: {}
   XboxOneIsContentPackage: 0
+  XboxOneEnhancedXboxCompatibilityMode: 0
   XboxOneEnableGPUVariability: 0
   XboxOneSockets: {}
   XboxOneSplashScreen: {fileID: 0}
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
   XboxOneXTitleMemory: 8
-  xboxOneScriptCompiler: 1
   XboxOneOverrideIdentityName: 
-  vrEditorSettings:
-    daydream:
-      daydreamIconForeground: {fileID: 0}
-      daydreamIconBackground: {fileID: 0}
+  XboxOneOverrideIdentityPublisher: 
+  vrEditorSettings: {}
   cloudServicesEnabled:
     UNet: 1
   luminIcon:
@@ -633,19 +794,16 @@ PlayerSettings:
   luminVersion:
     m_VersionCode: 1
     m_VersionName: 
-  facebookSdkVersion: 7.9.4
-  facebookAppId: 
-  facebookCookies: 1
-  facebookLogging: 1
-  facebookStatus: 1
-  facebookXfbml: 0
-  facebookFrictionlessRequests: 1
   apiCompatibilityLevel: 6
+  activeInputHandler: 0
+  windowsGamepadBackendHint: 0
   cloudProjectId: e733115d-57cb-4cf1-a3ab-49a625ed264e
   framebufferDepthMemorylessMode: 0
+  qualitySettingsNames: []
   projectName: SampleProject1 (1)
   organizationId: tomas1856
   cloudEnabled: 0
-  enableNativePlatformBackendsForNewInputSystem: 0
-  disableOldInputManagerSupport: 0
   legacyClampBlendShapeWeights: 0
+  playerDataPath: 
+  forceSRGBBlit: 1
+  virtualTexturingSupportEnabled: 0

--- a/TestProjects/SampleProject1/ProjectSettings/ProjectVersion.txt
+++ b/TestProjects/SampleProject1/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.40f1
-m_EditorVersionWithRevision: 2020.3.40f1 (ef997aeef7ca)
+m_EditorVersion: 2021.3.19f1
+m_EditorVersionWithRevision: 2021.3.19f1 (c9714fde33b6)

--- a/TestProjects/SampleProject1/ProjectSettings/UnityConnectSettings.asset
+++ b/TestProjects/SampleProject1/ProjectSettings/UnityConnectSettings.asset
@@ -9,6 +9,7 @@ UnityConnectSettings:
   m_EventOldUrl: https://api.uca.cloud.unity3d.com/v1/events
   m_EventUrl: https://cdp.cloud.unity3d.com/v1/events
   m_ConfigUrl: https://config.uca.cloud.unity3d.com
+  m_DashboardUrl: https://dashboard.unity3d.com
   m_TestInitMode: 0
   CrashReportingSettings:
     m_EventUrl: https://perf-events.cloud.unity3d.com
@@ -21,6 +22,8 @@ UnityConnectSettings:
   UnityAnalyticsSettings:
     m_Enabled: 0
     m_TestMode: 0
+    m_InitializeOnStartup: 1
+    m_PackageRequiringCoreStatsPresent: 0
   UnityAdsSettings:
     m_Enabled: 0
     m_InitializeOnStartup: 1

--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fixed an issue where logcat dispatcher would stop responding during domain reload.
  - Fixed an issue where MemoryWindow would fail to query memory stats using package name. It now uses process id instead.
  - Added Process Manager control which you can use to terminate an application or send a trim memory event.
+ - Fixed tag filtering, previously logcat would check if incoming_tag contains tag_in_filter, now it will perform incoming_tag equals tag_in_filter. That way it's easier to filter messages with tags which have the same begining.
  
 ## [1.4.0] - 2023-11-21
 ### Fixes & Improvements

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
@@ -354,7 +354,7 @@ namespace Unity.Android.Logcat
         {
             foreach (var tag in Tags)
             {
-                if (tagInMsg.Contains(tag))
+                if (tagInMsg.Equals(tag))
                     return true;
             }
 

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcat.cs
@@ -352,13 +352,7 @@ namespace Unity.Android.Logcat
 
         private bool MatchTagsFilter(string tagInMsg)
         {
-            foreach (var tag in Tags)
-            {
-                if (tagInMsg.Equals(tag))
-                    return true;
-            }
-
-            return false;
+            return Tags.Contains(tagInMsg);
         }
 
         private LogcatEntry ParseLogEntry(Match m)

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatInitializationTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatInitializationTests.cs
@@ -2,7 +2,6 @@ using System;
 using NUnit.Framework;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Unity.Android.Logcat;
 using UnityEngine;
 

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatMessageProviderTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatMessageProviderTests.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Collections;
-using System.Diagnostics;
 using NUnit.Framework;
 using Unity.Android.Logcat;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using UnityEngine.TestTools;
 
 internal class AndroidLogcatFakeMessageProvider : AndroidLogcatMessageProviderBase
 {
@@ -84,9 +81,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
     {
         foreach (var m in messages)
         {
-            if (m == null)
-                provider.SupplyFakeMessage(null);
-            else if (device.APILevel > 23)
+            if (device.APILevel > 23 && !string.IsNullOrEmpty(m))
                 provider.SupplyFakeMessage("1991-" + m);
             else
                 provider.SupplyFakeMessage(m);
@@ -215,7 +210,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             ),
         };
 
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
         foreach (var device in kDevices)
         {
             foreach (var check in checks)
@@ -246,7 +241,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             }
         }
 
-        ShutdownRuntime();
+
     }
 
     [TestCase(new string[] { "chromium" }, 2)]
@@ -265,7 +260,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             null
         };
 
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
 
         foreach (var device in kDevices)
@@ -287,7 +282,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         }
 
-        ShutdownRuntime();
+
     }
 
     [Test]
@@ -301,7 +296,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             @"10-25 14:27:56.863  2255  2255 I chromium: ABCDE",
         };
 
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         var logcat = new AndroidLogcat(m_Runtime, null, kDefaultDevice, -1, Priority.Verbose,
             new FilterOptions() { UseRegularExpressions = false, MatchCase = false },
@@ -369,7 +364,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         logcat.Stop();
 
-        ShutdownRuntime();
+
     }
 
     [Test]
@@ -384,7 +379,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             null
         };
 
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         var logcat = new AndroidLogcat(m_Runtime, null, kDefaultDevice, -1, Priority.Verbose,
             new FilterOptions() { UseRegularExpressions = true },
@@ -395,18 +390,16 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
         m_Runtime.OnUpdate();
 
         logcat.FilterOptions.Filter = "PPP";
-        Assert.AreEqual(3, logcat.RawEntries.Count);
+        Assert.AreEqual(2, logcat.RawEntries.Count);
         Assert.AreEqual(0, logcat.FilteredEntries.Count);
         Assert.AreEqual(true, logcat.FilterOptions.UseRegularExpressions);
 
         logcat.FilterOptions.Filter = @"\P";
-        Assert.AreEqual(3, logcat.RawEntries.Count);
-        Assert.AreEqual(3, logcat.FilteredEntries.Count);
+        Assert.AreEqual(2, logcat.RawEntries.Count);
+        Assert.AreEqual(2, logcat.FilteredEntries.Count);
         Assert.AreEqual(true, logcat.FilterOptions.UseRegularExpressions);
 
         logcat.Stop();
-
-        ShutdownRuntime();
     }
 
     [Test]
@@ -419,7 +412,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             @"10-25 14:27:56.863  3  2255 I chromium: "
         };
 
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         foreach (var device in kDevices)
         {
@@ -469,13 +462,13 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             }
         }
 
-        ShutdownRuntime();
+
     }
 
     [Test]
     public void MessagesSettingsWork()
     {
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         m_Runtime.Settings.MaxCachedMessageCount = 20;
         m_Runtime.Settings.MaxDisplayedMessageCount = 20;
@@ -514,21 +507,21 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         logcat.Stop();
 
-        ShutdownRuntime();
+
     }
 
     [Test]
     public void CanApplySettingsWithNullLogcat()
     {
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
         AndroidLogcatUtilities.ApplySettings(m_Runtime, null);
-        ShutdownRuntime();
+
     }
 
     [Test]
     public void MessageSelectionWorks()
     {
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         const int kMaxFilteredMessages = 20;
 
@@ -566,7 +559,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         logcat.Stop();
 
-        ShutdownRuntime();
+
     }
 
     [Test]
@@ -578,7 +571,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             "bbb",
             "ccc"
         };
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         var logcat = new AndroidLogcat(m_Runtime, null, kDefaultDevice, -1, Priority.Verbose, new FilterOptions(), new string[] { });
         logcat.Start();
@@ -608,7 +601,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         logcat.Stop();
 
-        ShutdownRuntime();
+
     }
 
 
@@ -621,7 +614,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
             "bbb",
             "ccc"
         };
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         var logcat = new AndroidLogcat(m_Runtime, null, kDefaultDevice, -1, Priority.Verbose, new FilterOptions(), new string[] { });
         logcat.Start();
@@ -659,6 +652,6 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         logcat.Stop();
 
-        ShutdownRuntime();
+
     }
 }

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatMessageProviderTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatMessageProviderTests.cs
@@ -249,9 +249,12 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
         ShutdownRuntime();
     }
 
-    [TestCase("chromium", 2)]
-    [TestCase("chromiu", 0)]
-    public void FilteringTagWorks(string tag, int expectedEntryCount)
+    [TestCase(new string[] { "chromium" }, 2)]
+    [TestCase(new string[] { "chromiu" }, 0)]
+    [TestCase(new string[] { "" }, 0)]
+    // Note: Empty or null messages are skipped.
+    [TestCase(null, 2)]
+    public void FilteringTagWorks(string[] tags, int expectedEntryCount)
     {
         var messages = new[]
         {
@@ -267,7 +270,7 @@ internal class AndroidLogcatMessagerProvideTests : AndroidLogcatRuntimeTestBase
 
         foreach (var device in kDevices)
         {
-            var logcat = new AndroidLogcat(m_Runtime, null, device, -1, Priority.Verbose, new FilterOptions(), new string[] { tag });
+            var logcat = new AndroidLogcat(m_Runtime, null, device, -1, Priority.Verbose, new FilterOptions(), tags);
             logcat.Start();
 
             SupplyFakeMessages((AndroidLogcatFakeMessageProvider)logcat.MessageProvider, device, messages);

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatPackageTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatPackageTests.cs
@@ -12,45 +12,38 @@ internal class AndroidLogcatPackageTests : AndroidLogcatRuntimeTestBase
     [Test]
     public void DeadPackagesAreCleanupCorrectly()
     {
-        try
+        using var autoRuntime = new AutoRuntime(this);
+
+        const int kPackagesToCreate = 10;
+        var fakeDevice = new AndroidLogcatFakeDevice90("androiddevice0");
+        for (int i = 0; i < kPackagesToCreate; i++)
         {
-            InitRuntime();
-
-            const int kPackagesToCreate = 10;
-            var fakeDevice = new AndroidLogcatFakeDevice90("androiddevice0");
-            for (int i = 0; i < kPackagesToCreate; i++)
-            {
-                var d = m_Runtime.UserSettings.CreateProcessInformation("com.unity.test" + i, i + 1, fakeDevice);
-            }
-
-            // All packages are alive, calling cleanup dead packages, shouldn't clean anything
-            m_Runtime.UserSettings.CleanupDeadProcessesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
-            var packages = m_Runtime.UserSettings.GetKnownProcesses(fakeDevice);
-            Assert.AreEqual(kPackagesToCreate, packages.Count);
-
-            foreach (var p in packages)
-                p.SetExited();
-
-            m_Runtime.UserSettings.CleanupDeadProcessesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
-
-            Assert.AreEqual(m_Runtime.Settings.MaxExitedPackagesToShow, packages.Count);
-
-            // Check that recent packages are still there, only the old packages should be removed
-            foreach (var p in packages)
-                Assert.IsTrue(p.processId > 5);
-
-            // Lower the number of max exited packages
-            m_Runtime.Settings.MaxExitedPackagesToShow = 4;
-            m_Runtime.UserSettings.CleanupDeadProcessesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
-            packages = m_Runtime.UserSettings.GetKnownProcesses(fakeDevice);
-            Assert.AreEqual(m_Runtime.Settings.MaxExitedPackagesToShow, packages.Count);
-
-            foreach (var p in packages)
-                Assert.IsTrue(p.processId > 6);
+            var d = m_Runtime.UserSettings.CreateProcessInformation("com.unity.test" + i, i + 1, fakeDevice);
         }
-        finally
-        {
-            ShutdownRuntime();
-        }
+
+        // All packages are alive, calling cleanup dead packages, shouldn't clean anything
+        m_Runtime.UserSettings.CleanupDeadProcessesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
+        var packages = m_Runtime.UserSettings.GetKnownProcesses(fakeDevice);
+        Assert.AreEqual(kPackagesToCreate, packages.Count);
+
+        foreach (var p in packages)
+            p.SetExited();
+
+        m_Runtime.UserSettings.CleanupDeadProcessesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
+
+        Assert.AreEqual(m_Runtime.Settings.MaxExitedPackagesToShow, packages.Count);
+
+        // Check that recent packages are still there, only the old packages should be removed
+        foreach (var p in packages)
+            Assert.IsTrue(p.processId > 5);
+
+        // Lower the number of max exited packages
+        m_Runtime.Settings.MaxExitedPackagesToShow = 4;
+        m_Runtime.UserSettings.CleanupDeadProcessesForDevice(fakeDevice, m_Runtime.Settings.MaxExitedPackagesToShow);
+        packages = m_Runtime.UserSettings.GetKnownProcesses(fakeDevice);
+        Assert.AreEqual(m_Runtime.Settings.MaxExitedPackagesToShow, packages.Count);
+
+        foreach (var p in packages)
+            Assert.IsTrue(p.processId > 6);
     }
 }

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatTestDeviceQueryTests.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatTestDeviceQueryTests.cs
@@ -18,7 +18,7 @@ class AndroidLogcatDeviceQueryTests : AndroidLogcatRuntimeTestBase
         m_UpdatedCount = 0;
         m_SelectedCount = 0;
         bool notUsed = true;
-        InitRuntime();
+        using var autoRuntime = new AutoRuntime(this);
 
         var query = (AndroidLogcatFakeDeviceQuery)m_Runtime.DeviceQuery;
         query.DeviceSelected += Query_DeviceSelected;
@@ -78,8 +78,6 @@ myandroid3 offline
 
         Assert.AreEqual(null, query.SelectedDevice);
         Assert.AreEqual(2, m_SelectedCount);
-
-        ShutdownRuntime();
     }
 
     private void Query_DevicesUpdated()

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatTestRuntime.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatTestRuntime.cs
@@ -49,6 +49,21 @@ internal class AndroidLogcatRuntimeTestBase
 {
     protected AndroidLogcatTestRuntime m_Runtime;
 
+    protected class AutoRuntime : IDisposable
+    {
+        AndroidLogcatRuntimeTestBase m_Parent;
+        public AutoRuntime(AndroidLogcatRuntimeTestBase parent)
+        {
+            m_Parent = parent;
+            m_Parent.InitRuntime();
+        }
+
+        public void Dispose()
+        {
+            m_Parent.ShutdownRuntime();
+        }
+    }
+
     protected void Cleanup()
     {
         if (Directory.Exists("Tests"))

--- a/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatTestRuntime.cs
+++ b/com.unity.mobile.android-logcat/Tests/Editor/AndroidLogcatTestRuntime.cs
@@ -52,15 +52,17 @@ internal class AndroidLogcatRuntimeTestBase
     protected class AutoRuntime : IDisposable
     {
         AndroidLogcatRuntimeTestBase m_Parent;
-        public AutoRuntime(AndroidLogcatRuntimeTestBase parent)
+        bool m_CleanUp;
+        public AutoRuntime(AndroidLogcatRuntimeTestBase parent, bool cleanup = true)
         {
             m_Parent = parent;
-            m_Parent.InitRuntime();
+            m_CleanUp = cleanup;
+            m_Parent.InitRuntime(m_CleanUp);
         }
 
         public void Dispose()
         {
-            m_Parent.ShutdownRuntime();
+            m_Parent.ShutdownRuntime(m_CleanUp);
         }
     }
 
@@ -70,7 +72,7 @@ internal class AndroidLogcatRuntimeTestBase
             Directory.Delete("Tests", true);
     }
 
-    protected void InitRuntime(bool cleanup = true)
+    protected void InitRuntime(bool cleanup)
     {
         if (m_Runtime != null)
             throw new Exception("Runtime was not shutdown by previous test?");
@@ -80,7 +82,7 @@ internal class AndroidLogcatRuntimeTestBase
         m_Runtime.Initialize();
     }
 
-    protected void ShutdownRuntime(bool cleanup = true)
+    protected void ShutdownRuntime(bool cleanup)
     {
         if (m_Runtime == null)
             throw new Exception("Runtime was not created?");


### PR DESCRIPTION
Bug fix for https://jira.unity3d.com/browse/ALB-38

Fixed tag filtering, instead of using logic "incoming_tag contains specified_tag", we'll use "incoming_tag equals specified_tag", this allows to efficiently filter messages with tags like Unity, UnityPlugin. Because previously if you specify to filter with Unity, UnityPlugin tag would be picked up too.

Added automated test to cover this scenario.
