### PR TITLE
Fix issue where logcat would throw errors when more than one device is connected

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2024-05-13
+### Fixes & Improvements
+ - Fix issue, where logcat package would throw an error if there are multiple devices connected.
+
 ## [1.4.1] - 2024-04-12
 ### Fixes & Improvements
  - Logcat package now detects if the logs with a specific tag are disabled on a device (this was causing messages not to be displayed), and if so, displays a message with an option to fix such behavior.

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatDevice.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatDevice.cs
@@ -250,8 +250,9 @@ namespace Unity.Android.Logcat
             if (m_Device == null || State != DeviceState.Connected)
                 return string.Empty;
 
-            var args = $"shell getprop log.tag.{tag}";
+            var args = $"-s {Id} shell getprop log.tag.{tag}";
             var output = m_ADB.Run(new[] { args }, $"Failed to get priority for tag '{tag}'");
+            AndroidLogcatInternalLog.Log($"adb {string.Join(" ", args)}\n{output}");
             return output;
         }
 
@@ -259,7 +260,8 @@ namespace Unity.Android.Logcat
         {
             if (m_Device == null || State != DeviceState.Connected)
                 return;
-            var args = $"shell setprop log.tag.{tag} {priority}";
+            var args = $"-s {Id} shell setprop log.tag.{tag} {priority}";
+            AndroidLogcatInternalLog.Log($"adb {string.Join(" ", args)}");
             m_ADB.Run(new[] { args }, $"Failed to set priority '{priority}' for tag '{tag}'");
         }
 

--- a/com.unity.mobile.android-logcat/package.json
+++ b/com.unity.mobile.android-logcat/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.mobile.android-logcat",
     "displayName": "Android Logcat",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "unity": "2021.3",
     "description": "Android Logcat package provides support for:\n - Android log messages\n - Android application memory statistics\n - Input injection\n - Android Screen Capture\n - Android Screen Recorder\n - Stacktrace Utility\n\nClick the 'View documentation' link above for more information.\n\nThe window can be accessed in Unity Editor via 'Window > Analysis > Android Logcat', or simply by pressing 'Alt+6' on Windows or 'Option+6' on macOS. \n\nMake sure to have Android module loaded and switch to Android build target in 'Build Settings' window if the menu doesn't exist.",
 	"keywords": ["Mobile", "Android", "Logcat"],


### PR DESCRIPTION
### Purpose of PR
**Type of change:**
- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe) 

* **Description of the feature**

https://jira.unity3d.com/browse/ALB-40


### Testing status

* **Detailed description of what testing was done, what projects were run**
* Launched two emulators
* Opened logcat
* Switched between two emulators, saw that no errors are shown in console