### PR TITLE
Preserve save location in screen capture window

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2025-01-01
+### Fixes & Improvements
+ - Fix Screen Capture window not saving last image/video save location correctly between Unity domain reloads or launches, previously it would always reset to Unity project directory.
+
 ## [1.4.1] - 2024-04-12
 ### Fixes & Improvements
  - Logcat package now detects if the logs with a specific tag are disabled on a device (this was causing messages not to be displayed), and if so, displays a message with an option to fix such behavior.

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatScreenCaptureWindow.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatScreenCaptureWindow.cs
@@ -22,17 +22,11 @@ namespace Unity.Android.Logcat
             public static GUIContent CaptureVideo = new GUIContent("Capture", "Record the video from the android device, click Stop afterwards to stop the recording.");
             public static GUIContent StopVideo = new GUIContent("Stop", "Stop the recording.");
         }
-        private enum Mode
+        internal enum Mode
         {
             Screenshot,
             Video
         }
-
-        [SerializeField]
-        private string[] m_ImagePath;
-        [SerializeField]
-        private Mode m_Mode;
-
         private AndroidLogcatRuntimeBase m_Runtime;
 
         private const int kButtonAreaHeight = 30;
@@ -48,12 +42,13 @@ namespace Unity.Android.Logcat
         {
             get
             {
-                switch (m_Mode)
+                var mode = m_Runtime.UserSettings.CaptureSettings.Mode;
+                switch (mode)
                 {
                     case Mode.Screenshot: return m_CaptureScreenshot.IsCapturing;
                     case Mode.Video: return m_CaptureVideo.IsRecording;
                     default:
-                        throw new NotImplementedException(m_Mode.ToString());
+                        throw new NotImplementedException(mode.ToString());
                 }
             }
         }
@@ -62,12 +57,13 @@ namespace Unity.Android.Logcat
         {
             get
             {
-                switch (m_Mode)
+                var mode = m_Runtime.UserSettings.CaptureSettings.Mode;
+                switch (mode)
                 {
                     case Mode.Screenshot: return m_CaptureScreenshot.GetImagePath(m_DeviceSelection.SelectedDevice);
                     case Mode.Video: return m_CaptureVideo.GetVideoPath(m_DeviceSelection.SelectedDevice);
                     default:
-                        throw new NotImplementedException(m_Mode.ToString());
+                        throw new NotImplementedException(mode.ToString());
                 }
             }
         }
@@ -157,7 +153,7 @@ namespace Unity.Android.Logcat
 
         void DoModeGUI()
         {
-            m_Mode = (Mode)EditorGUILayout.EnumPopup(m_Mode, AndroidLogcatStyles.toolbarPopup);
+            m_Runtime.UserSettings.CaptureSettings.Mode = (Mode)EditorGUILayout.EnumPopup(m_Runtime.UserSettings.CaptureSettings.Mode, AndroidLogcatStyles.toolbarPopup);
         }
 
         void OnGUI()
@@ -212,7 +208,7 @@ namespace Unity.Android.Logcat
         private void DoCaptureGUI()
         {
             EditorGUI.BeginDisabledGroup(m_DeviceSelection.SelectedDevice == null);
-            switch (m_Mode)
+            switch (m_Runtime.UserSettings.CaptureSettings.Mode)
             {
                 case Mode.Screenshot:
                     EditorGUI.BeginDisabledGroup(m_CaptureScreenshot.IsCapturing);
@@ -286,21 +282,17 @@ namespace Unity.Android.Logcat
             EditorGUI.BeginDisabledGroup(!File.Exists(TemporaryPath));
             if (GUILayout.Button(Styles.SaveAs, AndroidLogcatStyles.toolbarButton))
             {
-                var length = Enum.GetValues(typeof(Mode)).Length;
-                if (m_ImagePath == null || m_ImagePath.Length != length)
-                {
-                    var defaultDirectory = Path.Combine(Application.dataPath, "..");
-                    m_ImagePath = new string[length];
-                    for (int i = 0; i < length; i++)
-                        m_ImagePath[i] = defaultDirectory;
-                }
-
-                var path = EditorUtility.SaveFilePanel("Save Screen Capture", m_ImagePath[(int)m_Mode], Path.GetFileName(TemporaryPath), ExtensionForDialog);
+                var mode = m_Runtime.UserSettings.CaptureSettings.Mode;
+                var path = EditorUtility.SaveFilePanel(
+                    "Save Screen Capture",
+                    m_Runtime.UserSettings.CaptureSettings.GetLastSaveLocation(mode),
+                    Path.GetFileName(TemporaryPath),
+                    ExtensionForDialog);
                 if (!string.IsNullOrEmpty(path))
                 {
                     try
                     {
-                        m_ImagePath[(int)m_Mode] = Path.GetDirectoryName(path);
+                        m_Runtime.UserSettings.CaptureSettings.SetLastSaveLocation(mode, Path.GetFullPath(Path.GetDirectoryName(path)));
                         File.Copy(TemporaryPath, path, true);
                     }
                     catch (Exception ex)
@@ -314,7 +306,7 @@ namespace Unity.Android.Logcat
 
         private void DoPreviewGUI()
         {
-            switch (m_Mode)
+            switch (m_Runtime.UserSettings.CaptureSettings.Mode)
             {
                 case Mode.Screenshot:
                     {

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatScreenCaptureWindow.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatScreenCaptureWindow.cs
@@ -300,7 +300,7 @@ namespace Unity.Android.Logcat
                 {
                     try
                     {
-                        m_ImagePath[(int)m_Mode] = path;
+                        m_ImagePath[(int)m_Mode] = Path.GetDirectoryName(path);
                         File.Copy(TemporaryPath, path, true);
                     }
                     catch (Exception ex)

--- a/com.unity.mobile.android-logcat/Editor/AndroidLogcatUserSettings.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidLogcatUserSettings.cs
@@ -46,6 +46,39 @@ namespace Unity.Android.Logcat
             internal string DisplayId;
         }
 
+        [Serializable]
+        internal class ScreenCaptureSettings
+        {
+            [SerializeField]
+            internal AndroidLogcatScreenCaptureWindow.Mode Mode;
+            [SerializeField]
+            private string[] m_LastSaveLocation;
+
+            internal void SetLastSaveLocation(AndroidLogcatScreenCaptureWindow.Mode mode, string path)
+            {
+                if (m_LastSaveLocation == null || (int)mode >= m_LastSaveLocation.Length)
+                    ResetLastSaveLocation();
+                m_LastSaveLocation[(int)mode] = path;
+            }
+
+            internal string GetLastSaveLocation(AndroidLogcatScreenCaptureWindow.Mode mode)
+            {
+                if (m_LastSaveLocation == null || (int)mode >= m_LastSaveLocation.Length)
+                    ResetLastSaveLocation();
+                return m_LastSaveLocation[(int)mode];
+            }
+
+            internal void ResetLastSaveLocation()
+            {
+                var length = Enum.GetValues(typeof(AndroidLogcatScreenCaptureWindow.Mode)).Length;
+                var defaultDirectory = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+                m_LastSaveLocation = new string[length];
+                for (int i = 0; i < m_LastSaveLocation.Length; i++)
+                    m_LastSaveLocation[i] = defaultDirectory;
+
+            }
+        }
+
         [SerializeField]
         private string m_SelectedDeviceId;
         [SerializeField]
@@ -67,6 +100,8 @@ namespace Unity.Android.Logcat
         private List<ReordableListItem> m_SymbolPaths;
         [SerializeField]
         private VideoSettings m_CaptureVideoSettings;
+        [SerializeField]
+        private ScreenCaptureSettings m_ScreenCaptureSettings;
         [SerializeField]
         private InputSettings m_InputSettings;
 
@@ -128,6 +163,7 @@ namespace Unity.Android.Logcat
         }
 
         public VideoSettings CaptureVideoSettings { set => m_CaptureVideoSettings = value; get => m_CaptureVideoSettings; }
+        public ScreenCaptureSettings CaptureSettings { set => m_ScreenCaptureSettings = value; get => m_ScreenCaptureSettings; }
         public InputSettings DeviceInputSettings { set => m_InputSettings = value; get => m_InputSettings; }
 
         public AutoScroll AutoScroll { set => m_AutoScroll = value; get => m_AutoScroll; }
@@ -301,6 +337,7 @@ namespace Unity.Android.Logcat
             m_FilterOptions = new FilterOptions();
 
             ResetCaptureVideoSettings();
+            ResetScreenCaptureSettings();
 
             m_InputSettings = new InputSettings()
             {
@@ -324,6 +361,15 @@ namespace Unity.Android.Logcat
                 VideoSizeY = 720,
                 DisplayId = string.Empty
             };
+        }
+
+        internal void ResetScreenCaptureSettings()
+        {
+            m_ScreenCaptureSettings = new ScreenCaptureSettings
+            {
+                Mode = AndroidLogcatScreenCaptureWindow.Mode.Screenshot
+            };
+            m_ScreenCaptureSettings.ResetLastSaveLocation();
         }
 
         internal static AndroidLogcatUserSettings Load(string path)

--- a/com.unity.mobile.android-logcat/package.json
+++ b/com.unity.mobile.android-logcat/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.mobile.android-logcat",
     "displayName": "Android Logcat",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "unity": "2021.3",
     "description": "Android Logcat package provides support for:\n - Android log messages\n - Android application memory statistics\n - Input injection\n - Android Screen Capture\n - Android Screen Recorder\n - Stacktrace Utility\n\nClick the 'View documentation' link above for more information.\n\nThe window can be accessed in Unity Editor via 'Window > Analysis > Android Logcat', or simply by pressing 'Alt+6' on Windows or 'Option+6' on macOS. \n\nMake sure to have Android module loaded and switch to Android build target in 'Build Settings' window if the menu doesn't exist.",
 	"keywords": ["Mobile", "Android", "Logcat"],

--- a/com.unity.mobile.android-logcat/package.json
+++ b/com.unity.mobile.android-logcat/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.mobile.android-logcat",
     "displayName": "Android Logcat",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "unity": "2021.3",
     "description": "Android Logcat package provides support for:\n - Android log messages\n - Android application memory statistics\n - Input injection\n - Android Screen Capture\n - Android Screen Recorder\n - Stacktrace Utility\n\nClick the 'View documentation' link above for more information.\n\nThe window can be accessed in Unity Editor via 'Window > Analysis > Android Logcat', or simply by pressing 'Alt+6' on Windows or 'Option+6' on macOS. \n\nMake sure to have Android module loaded and switch to Android build target in 'Build Settings' window if the menu doesn't exist.",
 	"keywords": ["Mobile", "Android", "Logcat"],


### PR DESCRIPTION
## **Please read and consider what information you want to pass on to people reviewing this PR**

### Purpose of PR
**Type of change:**
- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe) 

* **Description of the feature**
The save location for screen capture was not correctly saved between domain reloads, we were saving file path instead of directory path

* **Links to Jira/Fogbugz cases**
https://jira.unity3d.com/browse/ALB-44

### Testing status
* **Existing or new automation tests - what automation was added, changed**
Non
* **Detailed description of what testing was done, what projects were run**
Did the following scenario:
* Open Screen Capture window, take screen shot, save it to D:/ folder
* Build & Run 
* Open Screen Capture window, take screen shot, ensure that D:/ folder is picked automatically as that was my last save location
