### PR TITLE
Migrate Mono APIs to CoreCLR-compatible APIs

### DIFF
--- a/com.unity.mobile.android-logcat/CHANGELOG.md
+++ b/com.unity.mobile.android-logcat/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.4.7] - 2025-12-12
 ### Fixes & Improvements
  - Don't periodically query for devices when none are connected and logcat window is unfocused.
- 
+ - Replace deprecated Mono APIs with CoreCLR-compatible APIs.
+
 ## [1.4.6] - 2025-06-07
 ### Fixes & Improvements
  - Stacktrace window will validate buildId when resolving stacktrace, informing you if wrong symbol file is used. Reset symbol regexes if needed.

--- a/com.unity.mobile.android-logcat/Editor/AndroidTools/AndroidBridge.cs
+++ b/com.unity.mobile.android-logcat/Editor/AndroidTools/AndroidBridge.cs
@@ -6,6 +6,9 @@ using System.Reflection;
 using UnityEngine;
 using UnityEditor;
 using Object = System.Object;
+#if UNITY_6000_5_OR_NEWER
+using UnityEngine.Assemblies;
+#endif
 
 namespace Unity.Android.Logcat
 {
@@ -38,7 +41,11 @@ namespace Unity.Android.Logcat
                 if (s_AndroidExtensions != null)
                     return s_AndroidExtensions;
                 var assemblyName = "UnityEditor.Android.Extensions";
+#if UNITY_6000_5_OR_NEWER
+                var loadedAssemblies = CurrentAssemblies.GetLoadedAssemblies();
+#else
                 var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+#endif
 
                 s_AndroidExtensions = loadedAssemblies.FirstOrDefault(a => a.FullName.Contains(assemblyName));
                 s_AndroidExtensionsState = s_AndroidExtensions == null ? ExtensionState.Unavalaible : ExtensionState.Available;


### PR DESCRIPTION
## Purpose of PR

This PR replaces all instances of analyzer-highlighted `Mono` API calls with `CoreCLR`-compatible API calls in this repo, and is part of Epic [SCP-1555](https://jira.unity3d.com/browse/SCP-1555).

## Further Context

- Unity is steadily moving away from `Mono` to using `CoreCLR`. 
- Epic [SCP-1555](https://jira.unity3d.com/browse/SCP-1555) tracks this work.
- For more information, please visit [#code-reload-safe-api-packages-migration](https://unity.enterprise.slack.com/archives/C09N2RM0L4D) 🙂 

### JIRA-ticket
- [SCP-1555](https://jira.unity3d.com/browse/SCP-1555)

## Testing
Running the default job-suite. Please share if there are additional steps needed!